### PR TITLE
ch(coverals)Redirect branch to develop

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -15,3 +15,4 @@ jobs:
       - run:
           name: run tests
           command: npm test
+                    coveralls

--- a/.coveralls.yml
+++ b/.coveralls.yml
@@ -1,0 +1,1 @@
+repo_token: qePAJEsz2fBBPtlaus7Aa3m2vCJPRCmBl

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 [![CircleCI](https://circleci.com/gh/AndelaOSP/art-dashboard.svg?style=svg)](https://circleci.com/gh/AndelaOSP/art-dashboard)
 # art-dashboard
-[![Coverage Status](https://coveralls.io/repos/github/AndelaOSP/art-dashboard/badge.svg?branch=master)](https://coveralls.io/github/AndelaOSP/art-dashboard?branch=master)
+[![Coverage Status](https://coveralls.io/repos/github/AndelaOSP/art-dashboard/badge.svg)](https://coveralls.io/github/AndelaOSP/art-dashboard)
 
 This is the admin dashboard for the ART application


### PR DESCRIPTION
- Redirect coveralls to default `develop` branch
[Delivers:#157929770]

## What does this PR do?
Redirects the coveralls badge to the develop branch

## Description of Task to be completed?
Change the coveralls badge on the README.md to point to the develop branch

## How should this be manually tested?
N/A

## What are the relevant pivotal tracker stories?
[#157929770](https://www.pivotaltracker.com/story/show/157929770)

## Any background context you want to add?
The coveralls badge had originally been directed to the then default `master` branch

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
N/A

## Todos
- [x] Raise PR
- [x] Documentation
## Screenshots
N/A