### PR TITLE
[#158862563] fix bug in add model number component

### DIFF
--- a/src/_components/ModelNumber/ModelNumberContainer.jsx
+++ b/src/_components/ModelNumber/ModelNumberContainer.jsx
@@ -96,7 +96,7 @@ ModelNumberContainer.defaultProps = {
 };
 
 const mapStateToProps = ({ assetMakesList, toastMessage }) => ({
-  assetMakes: assetMakesList,
+  assetMakes: assetMakesList.results,
   toastMessageContent: toastMessage
 });
 export default connect(mapStateToProps, {

--- a/src/components/ModelNumber/ModelNumberComponent.jsx
+++ b/src/components/ModelNumber/ModelNumberComponent.jsx
@@ -4,11 +4,10 @@ import PropTypes from 'prop-types';
 import ArtButton from '../common/ButtonComponent';
 import InputFluid from '../common/TextInputComponent';
 import DropdownComponent from '../common/DropdownComponent';
-
 import '../../_css/AddAssetComponent.css';
 
-const placeMakesInSemanticUIOptions = props =>
-  props.map((option, index) => ({
+const placeMakesInSemanticUIOptions = assetMakesList =>
+  assetMakesList.map((option, index) => ({
     key: index,
     text: option.make_label,
     value: option.id


### PR DESCRIPTION
## What does this PR do?
Fixes a bug in retrieving asset makes

## Description of Task to be completed?
On the asset make dropdown, the existing asset makes are not being listed.

## How should this be manually tested?
On login, go to assets. Click on the + plus icon on the asset model number, which opens the model number modal. Click on the asset makes dropdown and  the existing makes should be visible.

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/158862563

## Any background context you want to add?
N/A
## Important notes
N/A
## Packages installed
N/A
## Deployment note
N/A
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
<img width="877" alt="screen shot 2018-07-09 at 20 11 14" src="https://user-images.githubusercontent.com/27014080/42465318-4597a4d4-83b4-11e8-9112-0c83b2e1a914.png">
