### PR TITLE
[#158911251] Fix Subcategories Pagination Issue

### DIFF
--- a/src/_components/AssetTypes/AddAssetTypesContainer.jsx
+++ b/src/_components/AssetTypes/AddAssetTypesContainer.jsx
@@ -100,7 +100,7 @@ AddAssetTypesContainer.defaultProps = {
 };
 
 const mapStateToProps = ({ subcategoriesList, toastMessage }) => ({
-  subcategories: subcategoriesList.assetSubCategories,
+  subcategories: subcategoriesList.assetSubCategoriesDropdown,
   toastMessageContent: toastMessage
 });
 

--- a/src/_reducers/initialState.js
+++ b/src/_reducers/initialState.js
@@ -1,6 +1,7 @@
 export default {
   categories: [],
   subcategories: {
+    assetSubCategoriesDropdown: [],
     assetSubCategories: [],
     assetSubCategoriesCount: [],
     isLoading: false

--- a/src/_reducers/initialState.js
+++ b/src/_reducers/initialState.js
@@ -3,7 +3,7 @@ export default {
   subcategories: {
     assetSubCategoriesDropdown: [],
     assetSubCategories: [],
-    assetSubCategoriesCount: [],
+    assetSubCategoriesCount: 0,
     isLoading: false
   },
   assetTypes: [],

--- a/src/_reducers/subcategory.reducer.js
+++ b/src/_reducers/subcategory.reducer.js
@@ -20,7 +20,8 @@ export default (state = initialState.subcategories, action) => {
     case LOAD_SUBCATEGORIES_SUCCESS:
       return {
         ...state,
-        assetSubCategories: state.assetSubCategories.concat(action.payload.results),
+        assetSubCategoriesDropdown: state.assetSubCategories.concat(action.payload.results),
+        assetSubCategories: [...action.payload.results],
         assetSubCategoriesCount: action.payload.count,
         isLoading: false
       };
@@ -28,6 +29,7 @@ export default (state = initialState.subcategories, action) => {
     case LOAD_SUBCATEGORIES_FAILURE:
       return {
         ...state,
+        assetSubCategoriesDropdown: [],
         assetSubCategories: [],
         assetSubCategoriesCount: 0,
         isLoading: false

--- a/src/components/AssetsSubCategoriesComponent.jsx
+++ b/src/components/AssetsSubCategoriesComponent.jsx
@@ -23,7 +23,7 @@ export class AssetSubCategoriesComponent extends React.Component {
 
   handlePaginationChange = (e, { activePage }) => {
     this.setState({ activePage });
-    this.props.loadSubCategories(this.state.activePage);
+    this.props.loadSubCategories(activePage);
   }
 
   getTotalPages = () => Math.ceil(this.props.assetSubCategoriesCount / this.state.limit)


### PR DESCRIPTION
## What does this PR do?
Fix pagination for subcategories that was messed up
## Description of Task to be completed?
- add separate attribute in subcategories store
- fix pagination issue on AssetSubCategoriesComponent
## How should this be manually tested?
- Login and check the subcategories page. The pagination should show the 1st 10 results. The next page should show the next 4 results.
- Go to Assets page. Click on the `+` on the Asset Types column. the subcategories dropdown should have all 14 subcategories.
## What are the relevant pivotal tracker stories?
[#158911251](https://www.pivotaltracker.com/story/show/158911251)
## Any background context you want to add?
n/a
## Important notes
n/a
## Packages installed
n/a
## Deployment note
n/a
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots