### PR TITLE
feature(dropdown-fields): Clear all relevant fields after a dropdown value is changed

### DIFF
--- a/src/_components/Assets/AddAssetContainer.jsx
+++ b/src/_components/Assets/AddAssetContainer.jsx
@@ -87,15 +87,21 @@ class AddAssetContainer extends React.Component {
 
     if (name === 'asset-category') {
       this.setState({
-        filteredSubCategories: filterSubCategories(subcategories, value)
+        filteredSubCategories: filterSubCategories(subcategories, value),
+        filteredAssetTypes: filterAssetTypes(assetTypes, value),
+        filteredAssetMakes: filterAssetMakes(assetMakes, value),
+        filteredModelNumbers: filterModelNumbers(modelNumbers, value)
       });
     } else if (name === 'asset-subcategory') {
       this.setState({
-        filteredAssetTypes: filterAssetTypes(assetTypes, value)
+        filteredAssetTypes: filterAssetTypes(assetTypes, value),
+        filteredAssetMakes: filterAssetMakes(assetMakes, value),
+        filteredModelNumbers: filterModelNumbers(modelNumbers, value)
       });
     } else if (name === 'asset-types') {
       this.setState({
-        filteredAssetMakes: filterAssetMakes(assetMakes, value)
+        filteredAssetMakes: filterAssetMakes(assetMakes, value),
+        filteredModelNumbers: filterModelNumbers(modelNumbers, value)
       });
     } else if (name === 'asset-makes') {
       this.setState({


### PR DESCRIPTION
## What does this PR do?
This PR ensures the values following a drop-down option are subsequently changed whenever the drop-down option is changed.

## Description of Task to be completed?
- As a user adding an asset, after filling in all the other drop-down fields and I select a different category, then all other drop-down fields should be cleared. 
- When I change a subcategory and not category all other dropdowns after the subcategory field should be cleared. Similarly, with Asset Types and Asset Makes and Model Numbers.

## How should this be manually tested?
- Pull the branch
- Click on assets on the Side Menu. Once the assets table is displayed, click on the plus sign to add an asset.
- Add a `category`, `subcategory`, `type`, `make` then `model`. Change the `type` option, the `make` and `model` should change at this point. Changing the `category` option should have the same effect on the rest of the drop-down options.

## What are the relevant pivotal tracker stories?
[#158110055](https://www.pivotaltracker.com/n/projects/2146417/stories/158110055)

## Any background context you want to add?
- Prior to this, whenever a drop-down value was changed, the drop-down options coming after it would retain their values instead of changing subsequently.

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
- On adding all drop-down options
![screen shot 2018-07-16 at 15 21 56](https://user-images.githubusercontent.com/31322228/42759470-c7b1b5c6-890f-11e8-8807-626a190f4354.png)
- On changing the `type` option
![screen shot 2018-07-16 at 15 23 12](https://user-images.githubusercontent.com/31322228/42759486-d4aee9f6-890f-11e8-8165-757ed3b96983.png)
- On changing the `category` option
![screen shot 2018-07-16 at 15 23 21](https://user-images.githubusercontent.com/31322228/42759513-e4bc9a0a-890f-11e8-9f8e-338c3859ec17.png)
