### PR TITLE
#159462759 Users should see errors on the modal.

### DIFF
--- a/src/_components/AssetMake/AssetMakeContainer.jsx
+++ b/src/_components/AssetMake/AssetMakeContainer.jsx
@@ -28,13 +28,13 @@ class AssetMakeContainer extends React.Component {
         ToastMessage.success({
           message: toastMessageContent.message
         });
+        nextProps.toggleModal();
       } else if (toastMessageContent.type === 'error') {
         ToastMessage.error({
           message: toastMessageContent.message
         });
       }
       nextProps.resetToastMessageContent();
-      nextProps.toggleModal();
       return {
         assetMake: '',
         assetType: '',

--- a/src/_components/AssetTypes/AddAssetTypesContainer.jsx
+++ b/src/_components/AssetTypes/AddAssetTypesContainer.jsx
@@ -24,6 +24,7 @@ export class AddAssetTypesContainer extends React.Component {
         ToastMessage.success({
           message: toastMessageContent.message
         });
+        nextProps.toggleModal();
       } else if (toastMessageContent.type === 'error') {
         ToastMessage.error({
           message: toastMessageContent.message
@@ -31,8 +32,6 @@ export class AddAssetTypesContainer extends React.Component {
       }
 
       nextProps.resetToastMessageContent();
-      nextProps.toggleModal();
-
       return {
         assetType: '',
         subCategory: '',

--- a/src/_components/Category/CategoryContainer.jsx
+++ b/src/_components/Category/CategoryContainer.jsx
@@ -18,13 +18,14 @@ class CategoryContainer extends React.Component {
         ToastMessage.success({
           message: nextProps.toastMessageContent.message
         });
+        nextProps.toggleModal();
       } else if (nextProps.toastMessageContent.type === 'error') {
         ToastMessage.error({
           message: nextProps.toastMessageContent.message
         });
       }
       nextProps.resetToastMessageContent();
-      nextProps.toggleModal();
+
       return {
         categoryName: '',
         saveButtonState: false

--- a/src/_components/ModelNumber/ModelNumberContainer.jsx
+++ b/src/_components/ModelNumber/ModelNumberContainer.jsx
@@ -26,13 +26,13 @@ class ModelNumberContainer extends React.Component {
         ToastMessage.success({
           message: nextProps.toastMessageContent.message
         });
+        nextProps.toggleModal();
       } else if (nextProps.toastMessageContent.type === 'error') {
         ToastMessage.error({
           message: nextProps.toastMessageContent.message
         });
       }
       nextProps.resetToastMessageContent();
-      nextProps.toggleModal();
       return {
         modelNumber: '',
         assetMake: '',

--- a/src/_components/SubCategory/AddSubCategoriesContainer.jsx
+++ b/src/_components/SubCategory/AddSubCategoriesContainer.jsx
@@ -25,6 +25,7 @@ class AddSubCategoriesContainer extends React.Component {
         ToastMessage.success({
           message: toastMessageContent.message
         });
+        nextProps.toggleModal();
       } else if (toastMessageContent.type === 'error') {
         ToastMessage.error({
           message: toastMessageContent.message
@@ -32,8 +33,6 @@ class AddSubCategoriesContainer extends React.Component {
       }
 
       nextProps.resetToastMessageContent();
-      nextProps.toggleModal();
-
       return {
         subCategory: '',
         category: '',

--- a/src/_css/sharedStyling.scss
+++ b/src/_css/sharedStyling.scss
@@ -205,6 +205,7 @@ input,
     border-radius: 0;
   }
 }
+
 .ui-alerts {
   z-index: 4060;
 }

--- a/src/_css/sharedStyling.scss
+++ b/src/_css/sharedStyling.scss
@@ -205,3 +205,6 @@ input,
     border-radius: 0;
   }
 }
+.ui-alerts {
+  z-index: 4060;
+}


### PR DESCRIPTION
## What does this PR do?
Fixes display of error toast for  the modal components

## Description of Task to be completed?
#### Steps to reproduce
1. Visit asset lists page 
2. Click on the plus icon to add  a new category 
3. Add an existing category
#### Actual
The modal closes and the error is displayed as a toast message.
#### Expected
The error should be displayed on the modal
The modal should not close unless the user closes it.

## How should this be manually tested?
Once logged in, go to assets page. Click on any of the plus icons and on the opened model add an existing item, this should generate an error. The toast component will be displayed on the modal and the modal will not close until prompted by user.

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/159462759

## Any background context you want to add?
N/A
## Important notes
N/A
## Packages installed
N/A
## Deployment note
N/A
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
<img width="1493" alt="screen shot 2018-08-02 at 16 53 15" src="https://user-images.githubusercontent.com/27014080/43588184-9a929fca-9674-11e8-8c9c-19bf62adcb82.png">
