### PR TITLE
#159465815 Feature: Users should be able to see the navigation bar by default

### DIFF
--- a/src/__test__/components/NavBarComponent.test.js
+++ b/src/__test__/components/NavBarComponent.test.js
@@ -8,22 +8,22 @@ import localStorageMock from '../../_mock/localStorage';
 
 window.localStorage = localStorageMock;
 
-const props = {
+let props = {
   history: {
     push: jest.fn()
   },
   toggleVisibility: true
 };
 
-const wrapper = shallow(<NavBarComponent {...props} />);
+let wrapper = shallow(<NavBarComponent {...props} />);
 
 describe('renders <NavBarComponent />', () => {
   it('should render navbar menu component', () => {
     expect(wrapper.find('Menu').length).toEqual(1);
   });
 
-  it('should render hamburger icon', () => {
-    expect(wrapper.find('#hamburger').length).toEqual(1);
+  it('should render close label when open', () => {
+    expect(wrapper.find('.nav-button').length).toEqual(1);
   });
 
   it('should render andela banner icon', () => {
@@ -58,5 +58,20 @@ describe('renders <NavBarComponent />', () => {
     wrapper.find('#toggle-menu').simulate('click');
     wrapper.instance().toggleVisibility();
     expect(toggleVisibilitySpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should render hamburger icon when closed', () => {
+    props = {
+      history: {
+        push: jest.fn()
+      },
+      toggleVisibility: false
+    };
+    wrapper = shallow(<NavBarComponent {...props} />);
+    wrapper.setState({
+      visible: false
+    });
+
+    expect(wrapper.find('#hamburger').length).toEqual(1);
   });
 });

--- a/src/_css/NavBarComponent.scss
+++ b/src/_css/NavBarComponent.scss
@@ -132,7 +132,7 @@
   font-size: 15px;
 }
 
-.ui.secondary.menu .item .navButton {
+.ui.secondary.menu .item .nav-button {
   margin: 0;
   color: $andela-blue;
   background: none;

--- a/src/_css/NavBarComponent.scss
+++ b/src/_css/NavBarComponent.scss
@@ -19,6 +19,7 @@
   #hamburger {
     color: $andela-blue;
     cursor: pointer;
+    font-size: 20px;
   }
 
   #banner {
@@ -129,4 +130,16 @@
   max-width: 400px;
   margin-top: 1.5rem;
   font-size: 15px;
+}
+
+.ui.secondary.menu .item .navButton {
+  margin: 0;
+  color: $andela-blue;
+  background: none;
+  font-size: 12px;
+  padding-left: 0;
+
+  i {
+    font-size: 14px;
+  }
 }

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -42,7 +42,7 @@ export class NavBarComponent extends Component {
         </Label>
       );
     }
-    return (<Icon id="hamburger" name="bars" />);
+    return <Icon id="hamburger" name="bars" />;
   };
 
   render() {

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -37,7 +37,7 @@ export class NavBarComponent extends Component {
 
     if (visible) {
       return (
-        <Label className="navButton">
+        <Label className="nav-button">
           Close <Icon name="delete" />
         </Label>
       );

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -9,6 +9,7 @@ import {
   Menu,
   Icon,
   Image,
+  Label,
   Popup,
   Sidebar
 } from 'semantic-ui-react';
@@ -21,7 +22,7 @@ import AddAssetContainer from '../_components/Assets/AddAssetContainer';
 
 export class NavBarComponent extends Component {
   state = {
-    visible: false
+    visible: true
   };
 
   handleLogout = () => {
@@ -30,6 +31,19 @@ export class NavBarComponent extends Component {
   };
 
   toggleVisibility = () => this.setState({ visible: !this.state.visible });
+
+  navButton = () => {
+    const { visible } = this.state;
+
+    if (visible) {
+      return (
+        <Label className="navButton">
+          Close <Icon name="delete" />
+        </Label>
+      );
+    }
+    return (<Icon id="hamburger" name="bars" />);
+  };
 
   render() {
     const { visible } = this.state;
@@ -40,7 +54,7 @@ export class NavBarComponent extends Component {
       <div>
         <Menu id="nav-bar" secondary stackable>
           <Menu.Item id="toggle-menu" name="menu" onClick={this.toggleVisibility}>
-            <Icon id="hamburger" name="bars" />
+            {this.navButton()}
           </Menu.Item>
 
           <Menu.Item>
@@ -87,7 +101,8 @@ export class NavBarComponent extends Component {
                 <Dropdown.Item
                   id="logout"
                   onClick={this.handleLogout}
-                >Logout
+                >
+                  Logout
                 </Dropdown.Item>
               </Dropdown.Menu>
             </Dropdown>
@@ -103,18 +118,42 @@ export class NavBarComponent extends Component {
             <Grid textAlign="center">
               <Grid columns={6}>
                 <Grid.Column>
-                  <Link to="/dashboard"><span><Image className="nav-images" src="/images/analytics.png" /></span>Analytics</Link>
+                  <Link to="/dashboard">
+                    <span>
+                      <Image
+                        className="nav-images"
+                        src="/images/analytics.png"
+                      />
+                    </span>
+                    Analytics
+                  </Link>
                 </Grid.Column>
 
                 <Grid.Column>
-                  <Link to="/users"><span><Image className="nav-images" src="/images/users.png" /></span>Users</Link>
+                  <Link to="/users">
+                    <span>
+                      <Image
+                        className="nav-images"
+                        src="/images/users.png"
+                      />
+                    </span>
+                    Users
+                  </Link>
                 </Grid.Column>
 
                 <Grid.Column>
                   <Popup
                     id="assets-popup"
                     wide
-                    trigger={<span><Image className="nav-images" src="/images/assets.png" />Assets</span>}
+                    trigger={
+                      <span>
+                        <Image
+                          className="nav-images"
+                          src="/images/assets.png"
+                        />
+                        Assets
+                      </span>
+                    }
                     on="click"
                     position="bottom center"
                   >
@@ -154,15 +193,39 @@ export class NavBarComponent extends Component {
                 </Grid.Column>
 
                 <Grid.Column>
-                  <Link to="/incidence-reports"><span><Image className="nav-images" src="/images/reports.png" /></span>Reports</Link>
+                  <Link to="/incidence-reports">
+                    <span>
+                      <Image
+                        className="nav-images"
+                        src="/images/reports.png"
+                      />
+                    </span>
+                    Reports
+                  </Link>
                 </Grid.Column>
 
                 <Grid.Column>
-                  <Link to="/user-feedback"><span><Image className="nav-images" src="/images/feedback.png" /></span>Feedback</Link>
+                  <Link to="/user-feedback">
+                    <span>
+                      <Image
+                        className="nav-images"
+                        src="/images/feedback.png"
+                      />
+                    </span>
+                    Feedback
+                  </Link>
                 </Grid.Column>
 
                 <Grid.Column>
-                  <Link to="/allocations"><span><Image className="nav-images" src="/images/allocated.png" /></span>Allocations</Link>
+                  <Link to="/allocations">
+                    <span>
+                      <Image
+                        className="nav-images"
+                        src="/images/allocated.png"
+                      />
+                    </span>
+                    Allocations
+                  </Link>
                 </Grid.Column>
               </Grid>
             </Grid>


### PR DESCRIPTION
## What does this PR do?

Enables logged in users to view the navigation bar by default when they log in.

## Description of Task to be completed?

**Scenario:** Users should be able to see the navigation bar by default.
**Given**  An admin on the homepage
**Then** I should be able to see the navigation bar and close it when I wish to hide it.

## How should this be manually tested?

- Start the application
- Log in
- View the changes in the /dashboard url

## What are the relevant pivotal tracker stories?

[159465815](https://www.pivotaltracker.com/story/show/159465815)

## Any background context you want to add?

N/A

## Important notes

N/A

## Packages installed

N/A

## Deployment note

N/A

## Related PRs branch | PR (branch_name) | (pr_link)

N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots

<img width="841" alt="screen shot 2018-08-13 at 11 30 01" src="https://user-images.githubusercontent.com/31339738/44020990-50b0bcb8-9eec-11e8-8335-7410b431aecf.png">

<img width="841" alt="screen shot 2018-08-13 at 11 30 19" src="https://user-images.githubusercontent.com/31339738/44020995-54087fd6-9eec-11e8-8fcf-5c74272e71a6.png">
