### PR TITLE
#159468670 Fix asset list and asset detail display

### DIFF
--- a/src/__test__/_components/AddSubCategoriesContainer.test.js
+++ b/src/__test__/_components/AddSubCategoriesContainer.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import expect from 'expect';
+import SubCategory from '../../_components/SubCategory/AddSubCategoriesContainer';
+
+const props = {
+  toastMessageContent: {
+    type: 'success',
+    message: ''
+  },
+  loadCategoriesDropdown: jest.fn(),
+  createSubCategory: jest.fn(),
+  toggleModal: jest.fn(),
+  resetToastMessageContent: jest.fn(),
+  categoriesList: []
+};
+
+describe('Renders <AddSubCategoriesContainer /> tests', () => {
+  const wrapper = shallow(<SubCategory.WrappedComponent {...props} />);
+
+  it('calls the onAddSubCategory function', () => {
+    const onAddSubCategorySpy = jest.spyOn(
+      wrapper.instance(), 'onAddSubCategory'
+    );
+    const event = { target: { value: '' } };
+    const data = {};
+
+    wrapper.instance().onAddSubCategory(event, data);
+    expect(onAddSubCategorySpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the onSelectCategory function', () => {
+    const onSelectCategorySpy = jest.spyOn(
+      wrapper.instance(), 'onSelectCategory'
+    );
+    const event = { target: { value: '' } };
+    const data = {};
+
+    wrapper.instance().onSelectCategory(event, data);
+    expect(onSelectCategorySpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the onChangeButtonState function', () => {
+    const onChangeButtonStateSpy = jest.spyOn(
+      wrapper.instance(), 'onChangeButtonState'
+    );
+    const event = {};
+    const data = {};
+
+    wrapper.instance().onChangeButtonState(event, data);
+    expect(onChangeButtonStateSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the handleSubmit function', () => {
+    const handleSubmitSpy = jest.spyOn(
+      wrapper.instance(), 'handleSubmit'
+    );
+    const event = { target: { value: '', reset: jest.fn() } };
+    const data = {};
+
+    wrapper.instance().handleSubmit(event, data);
+    expect(handleSubmitSpy.mock.calls.length).toEqual(1);
+  });
+});

--- a/src/__test__/_components/CategoryContainer.test.js
+++ b/src/__test__/_components/CategoryContainer.test.js
@@ -1,0 +1,51 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import expect from 'expect';
+import Category from '../../_components/Category/CategoryContainer';
+
+const props = {
+  toastMessageContent: {
+    type: 'success',
+    message: ''
+  },
+  createCategory: jest.fn(),
+  toggleModal: jest.fn(),
+  resetToastMessageContent: jest.fn()
+};
+
+describe('Renders <CategoryContainer /> tests', () => {
+  const wrapper = shallow(<Category.WrappedComponent {...props} />);
+
+  it('calls the onChangeButtonState function', () => {
+    const onChangeButtonStateSpy = jest.spyOn(
+      wrapper.instance(), 'onChangeButtonState'
+    );
+    const event = {};
+    const data = {};
+
+    wrapper.instance().onChangeButtonState(event, data);
+    expect(onChangeButtonStateSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the handleSubmit function', () => {
+    const handleSubmitSpy = jest.spyOn(
+      wrapper.instance(), 'handleSubmit'
+    );
+    const event = { target: { value: '', reset: jest.fn() } };
+    const data = {};
+
+    wrapper.instance().handleSubmit(event, data);
+    expect(handleSubmitSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the onAddCategory function', () => {
+    const onAddCategorySpy = jest.spyOn(
+      wrapper.instance(), 'onAddCategory'
+    );
+    const event = { target: { value: '' } };
+    const data = {};
+
+    wrapper.instance().onAddCategory(event, data);
+    expect(onAddCategorySpy.mock.calls.length).toEqual(1);
+  });
+});

--- a/src/__test__/_components/ModelNumberContainer.test.js
+++ b/src/__test__/_components/ModelNumberContainer.test.js
@@ -1,0 +1,64 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import expect from 'expect';
+import ModelNumber from '../../_components/ModelNumber/ModelNumberContainer';
+
+const props = {
+  toastMessageContent: {
+    type: 'success',
+    message: ''
+  },
+  loadAssetMakesDropdown: jest.fn(),
+  createModelNumbers: jest.fn(),
+  toggleModal: jest.fn(),
+  resetToastMessageContent: jest.fn(),
+  assetMakes: []
+};
+
+describe('Renders <ModelNumberContainer /> tests', () => {
+  const wrapper = shallow(<ModelNumber.WrappedComponent {...props} />);
+
+  it('calls the onAddModelNumber function', () => {
+    const onAddModelNumberSpy = jest.spyOn(
+      wrapper.instance(), 'onAddModelNumber'
+    );
+    const event = { target: { value: '' } };
+    const data = {};
+
+    wrapper.instance().onAddModelNumber(event, data);
+    expect(onAddModelNumberSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the onSelectAssetMake function', () => {
+    const onSelectAssetMakeSpy = jest.spyOn(
+      wrapper.instance(), 'onSelectAssetMake'
+    );
+    const event = { target: { value: '' } };
+    const data = {};
+
+    wrapper.instance().onSelectAssetMake(event, data);
+    expect(onSelectAssetMakeSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the onChangeButtonState function', () => {
+    const onChangeButtonStateSpy = jest.spyOn(
+      wrapper.instance(), 'onChangeButtonState'
+    );
+    const event = {};
+    const data = {};
+
+    wrapper.instance().onChangeButtonState(event, data);
+    expect(onChangeButtonStateSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the handleSubmit function', () => {
+    const handleSubmitSpy = jest.spyOn(
+      wrapper.instance(), 'handleSubmit'
+    );
+    const event = { target: { value: '', reset: jest.fn() } };
+    const data = {};
+
+    wrapper.instance().handleSubmit(event, data);
+    expect(handleSubmitSpy.mock.calls.length).toEqual(1);
+  });
+});

--- a/src/_components/RoutesComponent.jsx
+++ b/src/_components/RoutesComponent.jsx
@@ -98,7 +98,7 @@ class RoutesComponent extends Component {
           <Authenticate
             exact
             isAuthenticated={this.checkAuthentication()}
-            path="/asset-makes"
+            path="/asset_makes"
             component={AssetMakes}
           />
           <Authenticate

--- a/src/_components/RoutesComponent.jsx
+++ b/src/_components/RoutesComponent.jsx
@@ -98,7 +98,7 @@ class RoutesComponent extends Component {
           <Authenticate
             exact
             isAuthenticated={this.checkAuthentication()}
-            path="/asset_makes"
+            path="/asset-makes"
             component={AssetMakes}
           />
           <Authenticate

--- a/src/components/AssetDetailComponent.jsx
+++ b/src/components/AssetDetailComponent.jsx
@@ -15,7 +15,7 @@ export class AssetDetailComponent extends Component {
     serialNumber: '',
     open: false,
     assignAssetButtonState: true
-  }
+  };
 
   componentDidMount() {
     this.getAssetId(this.props.location.pathname);
@@ -32,13 +32,7 @@ export class AssetDetailComponent extends Component {
   }
 
   shouldComponentUpdate(nextProps) {
-    if (
-      this.props.hasError &&
-      (this.props.errorMessage === nextProps.errorMessage)
-    ) {
-      return false;
-    }
-    return true;
+    return this.props.hasError && (this.props.errorMessage !== nextProps.errorMessage);
   }
 
   getAssetId(pathName) {
@@ -50,7 +44,7 @@ export class AssetDetailComponent extends Component {
 
   onSelectUserEmail = (event, data) => {
     this.setState({ selectedUser: data.value, assignAssetButtonState: false });
-  }
+  };
 
   handleAssign = () => {
     const { selectedUser } = this.state;
@@ -62,7 +56,7 @@ export class AssetDetailComponent extends Component {
     this.props.allocateAsset(assetAllocated, this.state.serialNumber);
 
     if (!this.props.buttonLoading) this.setState({ open: false });
-  }
+  };
 
   handleUnassign = () => {
     const { id } = this.props.assetDetail;
@@ -73,9 +67,9 @@ export class AssetDetailComponent extends Component {
     this.props.unassignAsset(assetAssigned, this.state.serialNumber);
 
     if (!this.props.buttonLoading) this.setState({ open: false });
-  }
+  };
 
-  show = () => this.setState({ open: true })
+  show = () => this.setState({ open: true });
 
   handleConfirm = () => {
     if (isEmpty(values(this.state.assignedUser))) {
@@ -84,7 +78,7 @@ export class AssetDetailComponent extends Component {
     return this.handleUnassign();
   };
 
-  handleCancel = () => this.setState({ open: false })
+  handleCancel = () => this.setState({ open: false });
 
   render() {
     return (

--- a/src/components/AssetDetailContent.jsx
+++ b/src/components/AssetDetailContent.jsx
@@ -85,10 +85,10 @@ const AssetDetailContent = (props) => {
                   <div><p>Asset Status</p></div>
                 </Grid.Column>
                 <Grid.Column className="details-description">
-                  <div><p>{assetDetail.asset_code}</p></div>
-                  <div><p>{assetDetail.serial_number}</p></div>
-                  <div><p>{assetDetail.model_number}</p></div>
-                  <div><p>{assetDetail.current_status}</p></div>
+                  <div><p>{assetDetail.asset_code ? assetDetail.asset_code : '-'}</p></div>
+                  <div><p>{assetDetail.serial_number ? assetDetail.serial_number : '-'}</p></div>
+                  <div><p>{assetDetail.model_number ? assetDetail.model_number : '-'}</p></div>
+                  <div><p>{assetDetail.current_status ? assetDetail.current_status : '-'}</p></div>
                 </Grid.Column>
               </Grid>
             </Grid.Column>

--- a/src/components/AssetDetailContent.jsx
+++ b/src/components/AssetDetailContent.jsx
@@ -85,10 +85,10 @@ const AssetDetailContent = (props) => {
                   <div><p>Asset Status</p></div>
                 </Grid.Column>
                 <Grid.Column className="details-description">
-                  <div><p>{assetDetail.asset_code ? assetDetail.asset_code : '-'}</p></div>
-                  <div><p>{assetDetail.serial_number ? assetDetail.serial_number : '-'}</p></div>
-                  <div><p>{assetDetail.model_number ? assetDetail.model_number : '-'}</p></div>
-                  <div><p>{assetDetail.current_status ? assetDetail.current_status : '-'}</p></div>
+                  <div><p>{assetDetail.asset_code || '-'}</p></div>
+                  <div><p>{assetDetail.serial_number || '-'}</p></div>
+                  <div><p>{assetDetail.model_number || '-'}</p></div>
+                  <div><p>{assetDetail.current_status || '-'}</p></div>
                 </Grid.Column>
               </Grid>
             </Grid.Column>

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -86,16 +86,19 @@ const AssetsTableContent = (props) => {
             props.activePageAssets.map((asset) => {
               const assetViewUrl = `assets/${asset.serial_number}/view`;
 
-              asset.asset_code = asset.asset_code ? asset.asset_code : '-';
-              asset.serial_number = asset.serial_number ? asset.serial_number : '-';
-              asset.model_number = asset.model_number ? asset.model_number : '-';
+              const updatedAsset = {
+                ...asset,
+                asset_code: asset.asset_code || '-',
+                serial_number: asset.serial_number || '-',
+                model_number: asset.model_number || '-'
+              };
 
               return (
                 <TableRowComponent
                   {...props}
                   viewDetailsRoute={assetViewUrl}
                   key={asset.id}
-                  data={asset}
+                  data={updatedAsset}
                   headings={[
                     'asset_code',
                     'serial_number',

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -67,15 +67,15 @@ const AssetsTableContent = (props) => {
               </ModalComponent>
             </Table.HeaderCell>
             <Table.HeaderCell>
-              Sub-category
-              <ModalComponent modalTitle="Add Sub-Category">
-                <AddSubCategoryContainer />
-              </ModalComponent>
-            </Table.HeaderCell>
-            <Table.HeaderCell>
               Category
               <ModalComponent modalTitle="Add Asset Category">
                 <CategoryContainer />
+              </ModalComponent>
+            </Table.HeaderCell>
+            <Table.HeaderCell>
+              Sub-category
+              <ModalComponent modalTitle="Add Sub-Category">
+                <AddSubCategoryContainer />
               </ModalComponent>
             </Table.HeaderCell>
           </Table.Row>
@@ -85,6 +85,11 @@ const AssetsTableContent = (props) => {
           {
             props.activePageAssets.map((asset) => {
               const assetViewUrl = `assets/${asset.serial_number}/view`;
+
+              asset.asset_code = asset.asset_code ? asset.asset_code : '-';
+              asset.serial_number = asset.serial_number ? asset.serial_number : '-';
+              asset.model_number = asset.model_number ? asset.model_number : '-';
+
               return (
                 <TableRowComponent
                   {...props}

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -163,7 +163,7 @@ export class NavBarComponent extends Component {
                       </Grid.Column>
 
                       <Grid.Column>
-                        <Link to="/asset_makes"><Icon name="list ul" />Asset Makes</Link>
+                        <Link to="/asset-makes"><Icon name="list ul" />Asset Makes</Link>
                       </Grid.Column>
 
                       <Grid.Column>


### PR DESCRIPTION
## What does this PR do?

Fixes how blank data is displayed on the asset list and asset detail pages

## Description of Task to be completed?

* If the asset code or the serial number is null from the response, display `-`
* Swap the `Category` and `Subcategory` headers.

## How should this be manually tested?

* Start the application
* Log in
* Navigate to the `Asset List` link
* View an asset with an empty `Serial Number` or `Asset Code`

## What are the relevant pivotal tracker stories?

[159468670](https://www.pivotaltracker.com/story/show/159468670)

## Any background context you want to add?

N/A

## Important notes

N/A

## Packages installed

N/A

## Deployment note

N/A

## Related PRs branch | PR (branch_name) | (pr_link)

N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots

