### PR TITLE
#159742621 Fix dropdowns to detect selected option

### DIFF
--- a/src/__test__/AddAssetMakeComponent.test.js
+++ b/src/__test__/AddAssetMakeComponent.test.js
@@ -51,6 +51,13 @@ describe('Renders <AddAssetMakeComponent /> correctly', () => {
     wrapper.find('.cancel').simulate('click');
     expect(toggleModal.callCount).toEqual(1);
   });
+
+  it('Should simulate form submit', () => {
+    const form = wrapper.find('Form');
+    expect(form.length).toEqual(1);
+    form.simulate('submit');
+    expect(props.handleSubmit.mock.calls.length).toEqual(1);
+  });
 });
 
 describe('Renders <AssetMakeContainer /> correctly', () => {
@@ -91,5 +98,15 @@ describe('Renders <AssetMakeContainer /> correctly', () => {
       }
     });
     expect(wrapper.props().toastMessageContent.type).toEqual('success');
+  });
+
+  it('should receive a message type prop when getDerivedStateFromProps loads', () => {
+    wrapper.setProps({
+      toastMessageContent: {
+        type: 'error',
+        message: 'An error occured'
+      }
+    });
+    expect(wrapper.props().toastMessageContent.type).toEqual('error');
   });
 });

--- a/src/__test__/AddAssetMakeComponent.test.js
+++ b/src/__test__/AddAssetMakeComponent.test.js
@@ -41,14 +41,14 @@ describe('Renders <AddAssetMakeComponent /> correctly', () => {
   });
 
   it('Should find the Save Button', () => {
-    expect(wrapper.find('.save-button').length).toEqual(1);
-    wrapper.find('.save-button').simulate('click');
+    expect(wrapper.find('.save').length).toEqual(1);
+    wrapper.find('.save').simulate('click');
     expect(onChangeButtonState.callCount).toEqual(1);
   });
 
   it('Should find the Cancel Button', () => {
-    expect(wrapper.find('.cancel-button').length).toEqual(1);
-    wrapper.find('.cancel-button').simulate('click');
+    expect(wrapper.find('.cancel').length).toEqual(1);
+    wrapper.find('.cancel').simulate('click');
     expect(toggleModal.callCount).toEqual(1);
   });
 });

--- a/src/_components/AssetMake/AssetMakeContainer.jsx
+++ b/src/_components/AssetMake/AssetMakeContainer.jsx
@@ -11,7 +11,7 @@ import resetToastMessageContent from '../../_actions/toastMessage.actions';
 class AssetMakeContainer extends React.Component {
   state = {
     assetMake: '',
-    assetType: '',
+    assetType: 0,
     saveButtonState: false
   };
 
@@ -37,7 +37,7 @@ class AssetMakeContainer extends React.Component {
       nextProps.resetToastMessageContent();
       return {
         assetMake: '',
-        assetType: '',
+        assetType: 0,
         saveButtonState: false
       };
     }
@@ -76,6 +76,7 @@ class AssetMakeContainer extends React.Component {
         onSelectAssetType={this.onSelectAssetType}
         onChangeButtonState={this.onChangeButtonState}
         buttonState={this.state.saveButtonState}
+        assetTypeSelectedId={this.state.assetType}
       />
     );
   }

--- a/src/_components/AssetTypes/AddAssetTypesContainer.jsx
+++ b/src/_components/AssetTypes/AddAssetTypesContainer.jsx
@@ -13,7 +13,7 @@ import resetToastMessageContent from '../../_actions/toastMessage.actions';
 export class AddAssetTypesContainer extends React.Component {
   state = {
     assetType: '',
-    subCategory: '',
+    subCategory: 0,
     saveButtonState: false
   };
 
@@ -34,7 +34,7 @@ export class AddAssetTypesContainer extends React.Component {
       nextProps.resetToastMessageContent();
       return {
         assetType: '',
-        subCategory: '',
+        subCategory: 0,
         saveButtonState: false
       };
     }
@@ -75,6 +75,7 @@ export class AddAssetTypesContainer extends React.Component {
         handleSubmit={this.handleSubmit}
         onChangeButtonState={this.onChangeButtonState}
         buttonState={this.state.saveButtonState}
+        subCategorySelectedId={this.state.subCategory}
         toggleModal={this.props.toggleModal}
       />
     );

--- a/src/_components/ModelNumber/ModelNumberContainer.jsx
+++ b/src/_components/ModelNumber/ModelNumberContainer.jsx
@@ -15,7 +15,7 @@ class ModelNumberContainer extends React.Component {
     super(props);
     this.state = {
       modelNumber: '',
-      assetMake: '',
+      assetMake: 0,
       saveButtonState: false
     };
   }
@@ -35,7 +35,7 @@ class ModelNumberContainer extends React.Component {
       nextProps.resetToastMessageContent();
       return {
         modelNumber: '',
-        assetMake: '',
+        assetMake: 0,
         saveButtonState: false
       };
     }
@@ -78,6 +78,7 @@ class ModelNumberContainer extends React.Component {
         handleSubmit={this.handleSubmit}
         onChangeButtonState={this.onChangeButtonState}
         buttonState={this.state.saveButtonState}
+        assetMakeSelectedId={this.state.assetMake}
         toggleModal={this.props.toggleModal}
       />
     );

--- a/src/_components/SubCategory/AddSubCategoriesContainer.jsx
+++ b/src/_components/SubCategory/AddSubCategoriesContainer.jsx
@@ -13,7 +13,7 @@ import resetToastMessageContent from '../../_actions/toastMessage.actions';
 class AddSubCategoriesContainer extends React.Component {
   state = {
     subCategory: '',
-    category: '',
+    category: 0,
     saveButtonState: false
   };
 
@@ -35,7 +35,7 @@ class AddSubCategoriesContainer extends React.Component {
       nextProps.resetToastMessageContent();
       return {
         subCategory: '',
-        category: '',
+        category: 0,
         saveButtonState: false
       };
     }
@@ -79,6 +79,7 @@ class AddSubCategoriesContainer extends React.Component {
         handleSubmit={this.handleSubmit}
         onChangeButtonState={this.onChangeButtonState}
         buttonState={this.state.saveButtonState}
+        categorySelectedId={this.state.category}
         toggleModal={this.props.toggleModal}
       />
     );

--- a/src/_css/ModalComponent.scss
+++ b/src/_css/ModalComponent.scss
@@ -194,4 +194,6 @@
 
 .modal-container {
   height: 450px;
+  overflow-y: auto;
+  overflow-x: hidden;
 }

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -69,6 +69,7 @@ const AssetDescriptionComponent = props => (
               label="Assign this asset to:"
               placeHolder="Select Andela Email To Assign This Asset"
               name="assign-user"
+              search
               onChange={props.onSelectUserEmail}
               options={userEmailsOptions(props.users)}
               value={props.selectedUser}

--- a/src/components/AssetDetailComponent.jsx
+++ b/src/components/AssetDetailComponent.jsx
@@ -11,7 +11,7 @@ import NavbarComponent from './NavBarComponent';
 export class AssetDetailComponent extends Component {
   state = {
     assignedUser: {},
-    selectedUser: '',
+    selectedUser: 0,
     serialNumber: '',
     open: false,
     assignAssetButtonState: true
@@ -96,6 +96,7 @@ export class AssetDetailComponent extends Component {
             handleAssign={this.handleAssign}
             handleUnassign={this.handleUnassign}
             open={this.state.open}
+            selectedUserId={this.state.selectedUser}
             show={this.show}
             handleConfirm={this.handleConfirm}
             handleCancel={this.handleCancel}

--- a/src/components/AssetMake/AddAssetMakeComponent.jsx
+++ b/src/components/AssetMake/AddAssetMakeComponent.jsx
@@ -33,22 +33,23 @@ const AddAssetMakeComponent = props => (
         label="Asset type"
         placeHolder="Select Asset type"
         name="asset-type"
+        value={props.assetTypeSelectedId}
         onChange={props.onSelectAssetType}
         options={assetTypeOptions(props.assetTypes)}
       />
     </label>
     <br />
     <ArtButton
-      className="save-button"
+      className="cancel"
+      buttonName="Cancel"
+      handleClick={props.toggleModal}
+    />
+    <ArtButton
+      className="save"
       buttonName="Save"
       color="primary"
       handleClick={props.onChangeButtonState}
       buttonState={props.buttonState}
-    />
-    <ArtButton
-      className="cancel-button"
-      buttonName="Cancel"
-      handleClick={props.toggleModal}
     />
   </Form>
 );
@@ -62,6 +63,7 @@ AddAssetMakeComponent.propTypes = {
   onaddAssetMake: PropTypes.func.isRequired,
   toggleModal: PropTypes.func.isRequired,
   assetTypes: PropTypes.array,
+  assetTypeSelectedId: PropTypes.number,
   onChangeButtonState: PropTypes.func.isRequired,
   buttonState: PropTypes.bool.isRequired,
   onSelectAssetType: PropTypes.func.isRequired

--- a/src/components/AssetTypes/AddAssetTypesComponent.jsx
+++ b/src/components/AssetTypes/AddAssetTypesComponent.jsx
@@ -30,6 +30,7 @@ const AssetTypesComponent = props => (
         label="Sub Category"
         placeHolder="Select Sub Category"
         name="subcategory"
+        value={props.subCategorySelectedId}
         onChange={props.onSelectSubCategory}
         options={placeMakesInSemanticUIOptions(props.subcategories)}
       />
@@ -58,7 +59,8 @@ AssetTypesComponent.propTypes = {
   toggleModal: PropTypes.func.isRequired,
   onChangeButtonState: PropTypes.func.isRequired,
   subcategories: PropTypes.array,
-  buttonState: PropTypes.bool.isRequired
+  buttonState: PropTypes.bool.isRequired,
+  subCategorySelectedId: PropTypes.number
 };
 
 AssetTypesComponent.defaultProps = {

--- a/src/components/Category/AddCategoryComponent.jsx
+++ b/src/components/Category/AddCategoryComponent.jsx
@@ -1,6 +1,6 @@
 import * as React from 'react';
 import PropTypes from 'prop-types';
-import { Form, Label } from 'semantic-ui-react';
+import { Form } from 'semantic-ui-react';
 import ArtButton from '../common/ButtonComponent';
 import InputFluid from '../common/TextInputComponent';
 
@@ -8,13 +8,15 @@ import '../../_css/AddAssetComponent.css';
 
 const AddCategoryComponent = props => (
   <Form onSubmit={props.handleSubmit}>
-    <Label htmlFor="category" className="label-style">Category Name</Label>
-    <InputFluid
-      name="category-name"
-      id="category"
-      onChange={props.onaddCategoryName}
-      placeholder="Enter Category Name"
-    />
+    <label htmlFor="model-number" className="label-style">
+      Category Name
+      <InputFluid
+        name="category-name"
+        id="category"
+        onChange={props.onaddCategoryName}
+        placeholder="Enter Category Name"
+      />
+    </label>
     <br />
     <ArtButton buttonName="Cancel" onClick={props.toggleModal} />
     <ArtButton buttonName="Save" color="primary" />

--- a/src/components/ModelNumber/ModelNumberComponent.jsx
+++ b/src/components/ModelNumber/ModelNumberComponent.jsx
@@ -32,20 +32,23 @@ const ModelNumberComponent = props => (
           label="Asset Makes"
           placeHolder="Select Asset Makes"
           name="asset-make"
+          value={props.assetMakeSelectedId}
           onChange={props.onSelectAssetMake}
           options={placeMakesInSemanticUIOptions(props.assetMakes)}
         />
       </label>
       <br />
       <ArtButton
+        className="cancel"
+        buttonName="Cancel"
+        handleClick={props.toggleModal}
+      />
+      <ArtButton
+        className="save"
         buttonName="Save"
         color="primary"
         handleClick={props.onChangeButtonState}
         buttonState={props.buttonState}
-      />
-      <ArtButton
-        buttonName="Cancel"
-        onClick={props.toggleModal}
       />
     </Form>
   </div>
@@ -58,6 +61,7 @@ ModelNumberComponent.propTypes = {
   toggleModal: PropTypes.func.isRequired,
   onChangeButtonState: PropTypes.func.isRequired,
   assetMakes: PropTypes.array,
+  assetMakeSelectedId: PropTypes.number,
   buttonState: PropTypes.bool.isRequired
 };
 

--- a/src/components/SubCategory/AddSubCategoryComponent.jsx
+++ b/src/components/SubCategory/AddSubCategoryComponent.jsx
@@ -15,31 +15,31 @@ const populateCategories = props =>
 const AddSubCategoryComponent = props => (
   <Form onSubmit={props.handleSubmit}>
     <label htmlFor="category" className="label-style">
+      <label htmlFor="sub-category" className="label-style">
+        Sub-Category
+        <InputFluid
+          name="sub-category"
+          onChange={props.onAddSubCategory}
+          placeHolder="Enter Sub-Category"
+        />
+      </label>
+      <br />
       Category
       <DropdownComponent
         customClass="form-dropdown"
         label="Categories"
         placeHolder="Select A Category"
         name="category"
+        value={props.categorySelectedId}
         onChange={props.onSelectCategory}
         options={populateCategories(props.categoriesList)}
       />
     </label>
 
     <br />
-    <label htmlFor="sub-category" className="label-style">
-      Sub-Category
-      <InputFluid
-        name="sub-category"
-        onChange={props.onAddSubCategory}
-        placeHolder="Enter Sub-Category"
-      />
-    </label>
-
-    <br />
     <ArtButton
       buttonName="Cancel"
-      onClick={props.toggleModal}
+      handleClick={props.toggleModal}
     />
     <ArtButton
       buttonName="Save"
@@ -53,6 +53,7 @@ const AddSubCategoryComponent = props => (
 
 AddSubCategoryComponent.propTypes = {
   categoriesList: PropTypes.array,
+  categorySelectedId: PropTypes.number,
   buttonState: PropTypes.bool.isRequired,
   handleSubmit: PropTypes.func.isRequired,
   onAddSubCategory: PropTypes.func.isRequired,

--- a/src/components/common/ModalComponent.jsx
+++ b/src/components/common/ModalComponent.jsx
@@ -44,7 +44,7 @@ export default class ArtModal extends Component {
           closeIcon
         >
           <Modal.Header>{this.props.modalTitle} <div className="underline" /></Modal.Header>
-          <Modal.Content style={{ overflowY: 'auto' }}>
+          <Modal.Content>
             <Modal.Description style={{ width: '100%' }}>
               {childrenWithProps}
             </Modal.Description>


### PR DESCRIPTION
## What does this PR do?

- Fixes the dropdown bug so that they should detect change in selected option.

## Description of Task to be completed?
**Expected**

- Case 1: On clicking the + icons on the Asset lists page, the dropdown on displayed modal popup should detect a change in selected value and display it on the input field.

- Case 2: When assigning an asset, user should be able to select an email on the dropdown.

**Current**

- Once a value is selected, the dropdown does not detect the change and value not displayed as the selected option.
This  affects:
_Model Number,_
_Asset Make,_
_Asset type_
_Sub Category_
_Assign Asset_

## How should this be manually tested?

- Once logged in, on the Assets Lists page, click on any of the + icons. 

- On the modal displayed, try changing value of selected option on the dropdown. The selected option should be displayed on the input field.

## What are the relevant pivotal tracker stories?

- https://www.pivotaltracker.com/story/show/159742621

## Any background context you want to add?
N/a
## Important notes
N/a
## Packages installed
N/a
## Deployment note
N/a
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
<img width="627" alt="screen shot 2018-08-14 at 16 51 49" src="https://user-images.githubusercontent.com/27014080/44095807-651c2d6c-9fe2-11e8-825e-b1111946cd9d.png">

<img width="481" alt="screen shot 2018-08-14 at 16 52 27" src="https://user-images.githubusercontent.com/27014080/44095839-77a8fa8c-9fe2-11e8-8096-2c35cba25c09.png">
