### PR TITLE
#159470729 Table should always be displayed

### DIFF
--- a/src/__test__/AllocationComponent.test.js
+++ b/src/__test__/AllocationComponent.test.js
@@ -9,7 +9,8 @@ describe('Renders <Allocations/> component', () => {
   const props = {
     loadAllocationsAction: jest.fn(),
     allAllocations: [],
-    isLoading: true
+    isLoading: true,
+    hasError: false
   };
 
   let wrapper;
@@ -19,14 +20,16 @@ describe('Renders <Allocations/> component', () => {
     expect(wrapper.find('LoaderComponent').length).toBe(1);
   });
 
-  it('renders error if allocations fail to load', () => {
+  it('renders a message is hasError is true', () => {
     props.isLoading = false;
+    props.hasError = true;
     wrapper = shallow(<AllocationsComponent {...props} />);
-    expect(wrapper.find('h1').text()).toEqual('No Assets Currently Assigned');
+    expect(wrapper.find('h1').text()).toEqual('An Error Occurred While Trying To Display Allocations.');
   });
 
   it('renders table when allocations are loaded successfully', () => {
     props.isLoading = false;
+    props.hasError = false;
     props.allAllocations = allocations;
     wrapper = shallow(<AllocationsComponent {...props} />);
     expect(wrapper.find('Header').prop('content')).toEqual('All Allocations');

--- a/src/__test__/AssetCategoriesComponent.test.js
+++ b/src/__test__/AssetCategoriesComponent.test.js
@@ -38,14 +38,6 @@ describe('Asset Categories Component', () => {
     expect(wrapper.find('DropdownComponent').length).toBe(1);
   });
 
-  it('renders error message if there are no asset categories', () => {
-    wrapper.setProps({
-      isLoading: false,
-      categories: []
-    });
-    expect(wrapper.find('h1').text()).toEqual('No Asset Categories Found.');
-  });
-
   it('renders a Loading Component if isLoading is true', () => {
     wrapper.setProps({
       isLoading: true
@@ -58,6 +50,6 @@ describe('Asset Categories Component', () => {
       hasError: true,
       isLoading: false
     });
-    expect(wrapper.find('h1').text()).toEqual('An Error Occurred While Trying To Display The Asset Categories');
+    expect(wrapper.find('h1').text()).toEqual('An Error Occurred While Trying To Display The Asset Categories.');
   });
 });

--- a/src/__test__/AssetSpecsComponent.test.js
+++ b/src/__test__/AssetSpecsComponent.test.js
@@ -11,6 +11,7 @@ describe('Renders < AssetSpecsComponent /> correctly', () => {
     loadAssetSpecs: jest.fn(),
     handlePaginationChange: jest.fn(),
     isLoading: false,
+    hasError: false,
     specs,
     assetSpecsCount: 10
   };
@@ -42,13 +43,14 @@ describe('Renders < AssetSpecsComponent /> correctly', () => {
     expect(wrapper.find('Table').length).toBe(1);
   });
 
-  it('displays No Asset Spec Found', () => {
+  it('displays An Error Occured if hasError is true', () => {
     props.isLoading = false;
+    props.hasError = true;
     props.specs = [];
     wrapper = shallow(<AssetSpecsComponent
       {...props}
     />);
-    expect(wrapper.find('h1').text()).toBe('No Asset Spec Found');
+    expect(wrapper.find('h1').text()).toBe('An Error Occured');
   });
 
   it('calls the handlePaginationChange function when the next button is clicked', () => {

--- a/src/__test__/AssetTypesComponent.test.js
+++ b/src/__test__/AssetTypesComponent.test.js
@@ -11,6 +11,7 @@ describe('Renders <AssetTypesComponent /> correctly', () => {
     loadAssetTypes: jest.fn(),
     handlePaginationChange: jest.fn(),
     isLoading: false,
+    hasError: false,
     assetTypes,
     assetTypesCount: 6
   };
@@ -57,11 +58,12 @@ describe('Renders <AssetTypesComponent /> correctly', () => {
     expect(handlePaginationChangeSpy.mock.calls.length).toEqual(1);
   });
 
-  it('renders message if no asset types are returned', () => {
+  it('renders message if an error occurs', () => {
     wrapper.setProps({
       isLoading: false,
+      hasError: true,
       assetTypes: []
     });
-    expect(wrapper.find('h1').text()).toEqual('No Asset Types Found');
+    expect(wrapper.find('h1').text()).toEqual('An Error Occurred While Trying To Display The Asset Types.');
   });
 });

--- a/src/__test__/AssetsTableContent.test.js
+++ b/src/__test__/AssetsTableContent.test.js
@@ -43,12 +43,4 @@ describe('Renders <AssetsTableContent /> correctly', () => {
     wrapper.setProps({ hasError: true, isLoading: false, errorMessage: 'An error' });
     expect(wrapper.find('SemanticToastContainer').length).toBe(1);
   });
-
-  it('renders message if there are no assets returned', () => {
-    wrapper.setProps({
-      emptyAssetsCheck: () => (true),
-      hasError: false
-    });
-    expect(wrapper.find('#empty-assets').prop('content')).toEqual('No Assets Found');
-  });
 });

--- a/src/__test__/components/AssetConditionsComponent.test.js
+++ b/src/__test__/components/AssetConditionsComponent.test.js
@@ -11,22 +11,25 @@ describe('Renders <AssetConditionsComponent/> component', () => {
     handlePaginationChange: jest.fn(),
     assetConditionsList: assetConditions,
     assetConditionsCount: 3,
-    isLoading: false
+    isLoading: false,
+    hasError: false
   };
 
   const wrapper = shallow(<AssetConditionsComponent {...props} />);
 
-  it('renders error if no asset conditions are found', () => {
+  it('renders message if an error occurs', () => {
     wrapper.setProps({
       isLoading: false,
+      hasError: true,
       assetConditionsList: []
     });
-    expect(wrapper.find('h1').text()).toEqual('No Asset Conditions Found');
+    expect(wrapper.find('h1').text()).toEqual('An Error Occurred While Trying To Display The Asset Conditions.');
   });
 
   it('renders table when asset conditions are loaded successfully', () => {
     wrapper.setProps({
       isLoading: false,
+      hasError: false,
       assetConditionsList: assetConditions,
       assetConditionsCount: 3
     });

--- a/src/__test__/components/AssetModelsComponent.test.js
+++ b/src/__test__/components/AssetModelsComponent.test.js
@@ -11,6 +11,7 @@ describe('Renders <AssetModelsComponent /> correctly', () => {
     loadAssetModels: jest.fn(),
     handlePaginationChange: jest.fn(),
     isLoading: false,
+    hasError: false,
     assetModels,
     assetModelsCount: 3
   };
@@ -55,11 +56,13 @@ describe('Renders <AssetModelsComponent /> correctly', () => {
     expect(handlePaginationChangeSpy.mock.calls.length).toEqual(1);
   });
 
-  it('renders message if no asset models are returned', () => {
+  it('renders message if an error occus', () => {
     wrapper.setProps({
       isLoading: false,
+      hasError: true,
       assetModels: []
     });
-    expect(wrapper.find('h1').text()).toEqual('No Asset Models Found');
+    expect(wrapper.find('h1').text())
+      .toEqual('An Error Occurred While Trying To Display The Incidence Reports.');
   });
 });

--- a/src/__test__/components/UserFeedbackComponent.test.js
+++ b/src/__test__/components/UserFeedbackComponent.test.js
@@ -12,6 +12,7 @@ describe('<UserFeedbackComponent /> tests', () => {
     handlePaginationChange: jest.fn(),
     handleRowChange: jest.fn(),
     isLoading: false,
+    hasError: false,
     feedback,
     feedbackCount: 3
   };
@@ -59,14 +60,15 @@ describe('<UserFeedbackComponent /> tests', () => {
     expect(handlePaginationChangeSpy.mock.calls.length).toEqual(1);
   });
 
-  it('renders message if no user feedback is returned', () => {
+  it('renders message if hasError is true', () => {
     wrapper.setProps({
       isLoading: false,
+      hasError: true,
       feedback: [],
       feedbackCount: 0
     });
 
-    expect(wrapper.find('h1').text()).toEqual('No Feedback Found');
+    expect(wrapper.find('h1').text()).toEqual('An Error Occurred While Trying To Display User Feedback.');
   });
 
   it('calls the handleRowChange function when the row dropdown is changed', () => {

--- a/src/__test__/components/UsersComponent.test.js
+++ b/src/__test__/components/UsersComponent.test.js
@@ -36,17 +36,6 @@ describe('Renders UserComponent with the LoadingComponent', () => {
   });
 });
 
-describe('Renders UserComponent with the Header Component', () => {
-  props = {
-    emptyUsersList: () => true
-  };
-  const wrapper3 = shallow(<UserComponent {...props} />);
-
-  it('renders Header Component if there are no users on the backend', () => {
-    expect(wrapper3.find('Header').length).toBe(1);
-  });
-});
-
 describe('Renders UserComponent with the SemanticToastContainer', () => {
   props = {
     hasError: true,

--- a/src/__test__/reducers/assetTypes.reducer.test.js
+++ b/src/__test__/reducers/assetTypes.reducer.test.js
@@ -16,7 +16,8 @@ const {
 
 const initialState = {
   assetTypes: [],
-  isLoading: false
+  isLoading: false,
+  hasError: false
 };
 
 const action = { payload: {} };
@@ -54,7 +55,8 @@ describe('Asset Type Reducer tests', () => {
     };
     const newState = {
       assetTypes: assetTypesMock,
-      isLoading: false
+      isLoading: false,
+      hasError: false
     };
     action.type = LOAD_ASSET_TYPES_SUCCESS;
     action.payload = { results: assetTypesMock };
@@ -71,7 +73,8 @@ describe('Asset Type Reducer tests', () => {
     const newAction = {};
     const newState = {
       assetTypes: assetTypesMock,
-      isLoading: false
+      isLoading: false,
+      hasError: false
     };
     action.type = LOAD_ASSET_TYPES_SUCCESS;
     action.payload = { results: assetTypesMock };

--- a/src/_reducers/allocations.reducer.js
+++ b/src/_reducers/allocations.reducer.js
@@ -14,13 +14,15 @@ export default (state = initialState.allocations, action) => {
         ...state,
         allAllocations: [...action.payload.results],
         allocationsCount: action.payload.count,
-        isLoading: false
+        isLoading: false,
+        hasError: false
       };
     case LOAD_ALLOCATIONS_FAILURE:
       return {
         ...state,
         allAllocations: [],
-        isLoading: false
+        isLoading: false,
+        hasError: true
       };
     case LOADING_ALLOCATIONS:
       return {

--- a/src/_reducers/assetCondition.reducer.js
+++ b/src/_reducers/assetCondition.reducer.js
@@ -20,7 +20,8 @@ export default (state = initialState.assetConditions, action) => {
         ...state,
         assetConditionsList: action.payload.results,
         assetConditionsCount: action.payload.count,
-        isLoading: false
+        isLoading: false,
+        hasError: false
       };
 
     case LOAD_ASSET_CONDITION_FAILURE:
@@ -28,7 +29,8 @@ export default (state = initialState.assetConditions, action) => {
         ...state,
         assetConditionsList: [],
         assetConditionsCount: 0,
-        isLoading: false
+        isLoading: false,
+        hasError: true
       };
 
     default:

--- a/src/_reducers/assetMake.reducer.js
+++ b/src/_reducers/assetMake.reducer.js
@@ -16,7 +16,8 @@ export default (state = initialState.assetMakes, action) => {
         ...state,
         assetMakes: action.payload.results,
         assetMakesCount: action.payload.count,
-        isLoading: false
+        isLoading: false,
+        hasError: false
       };
     case DROPDOWN_ASSET_MAKES_SUCCESS:
       return {
@@ -27,7 +28,8 @@ export default (state = initialState.assetMakes, action) => {
     case LOAD_ASSET_MAKES_FAILURE:
       return {
         ...state,
-        isLoading: false
+        isLoading: false,
+        hasError: true
       };
     case LOADING_ASSET_MAKES:
       return {

--- a/src/_reducers/assetModels.reducer.js
+++ b/src/_reducers/assetModels.reducer.js
@@ -9,7 +9,8 @@ const {
 const initialState = {
   assetModels: [],
   assetModelsCount: 0,
-  isLoading: false
+  isLoading: false,
+  hasError: false
 };
 
 export default (state = initialState, action) => {
@@ -25,7 +26,8 @@ export default (state = initialState, action) => {
         ...state,
         assetModels: [...action.payload.results],
         assetModelsCount: action.payload.count,
-        isLoading: false
+        isLoading: false,
+        hasError: false
       };
 
     case LOAD_ASSET_MODELS_FAILURE:
@@ -33,7 +35,8 @@ export default (state = initialState, action) => {
         ...state,
         assetModels: [],
         assetModelsCount: 0,
-        isLoading: false
+        isLoading: false,
+        hasError: true
       };
 
     default:

--- a/src/_reducers/assetTypes.reducer.js
+++ b/src/_reducers/assetTypes.reducer.js
@@ -13,7 +13,8 @@ const {
 const initialState = {
   assetTypes: [],
   assetTypesCount: 0,
-  isLoading: false
+  isLoading: false,
+  hasError: false
 };
 
 export default (state = initialState, action) => {
@@ -28,14 +29,16 @@ export default (state = initialState, action) => {
         ...state,
         assetTypes: [...action.payload.results],
         assetTypesCount: action.payload.count,
-        isLoading: false
+        isLoading: false,
+        hasError: false
       };
     case LOAD_ASSET_TYPES_FAILURE:
       return {
         ...state,
         assetTypes: [],
         assetTypesCount: 0,
-        isLoading: false
+        isLoading: false,
+        hasError: true
       };
     case LOAD_DROPDOWN_ASSET_TYPES_SUCCESS:
       return {

--- a/src/_reducers/incidenceReports.reducer.js
+++ b/src/_reducers/incidenceReports.reducer.js
@@ -19,6 +19,7 @@ const loadIncidenceReportsReducer = (state = initialState.incidenceReports, acti
       return {
         ...state,
         isLoading: false,
+        hasError: false,
         reports: action.incidenceReports.results,
         incidenceReportsCount: action.incidenceReports.count
       };

--- a/src/_reducers/initialState.js
+++ b/src/_reducers/initialState.js
@@ -7,14 +7,16 @@ export default {
     assetSubCategoriesDropdown: [],
     assetSubCategories: [],
     assetSubCategoriesCount: 0,
-    isLoading: false
+    isLoading: false,
+    hasError: false
   },
   assetTypes: [],
   assetMakes: {
     assetMake: [],
     assetMakes: [],
     assetMakesCount: 0,
-    isLoading: false
+    isLoading: false,
+    hasError: false
   },
   modelNumbers: [],
   assetModels: [],
@@ -62,7 +64,8 @@ export default {
   assetConditions: {
     assetConditionsList: [],
     assetConditionsCount: 0,
-    isLoading: false
+    isLoading: false,
+    hasError: false
   },
   usersList: {
     users: [],

--- a/src/_reducers/subcategory.reducer.js
+++ b/src/_reducers/subcategory.reducer.js
@@ -23,7 +23,8 @@ export default (state = initialState.subcategories, action) => {
         ...state,
         assetSubCategories: [...action.payload.results],
         assetSubCategoriesCount: action.payload.count,
-        isLoading: false
+        isLoading: false,
+        hasError: false
       };
 
     case DROPDOWN_SUBCATEGORIES_SUCCESS:
@@ -39,7 +40,8 @@ export default (state = initialState.subcategories, action) => {
         assetSubCategoriesDropdown: [],
         assetSubCategories: [],
         assetSubCategoriesCount: 0,
-        isLoading: false
+        isLoading: false,
+        hasError: true
       };
 
     case CREATE_SUBCATEGORY_SUCCESS:

--- a/src/_reducers/userFeedback.reducer.js
+++ b/src/_reducers/userFeedback.reducer.js
@@ -11,12 +11,14 @@ export default (state = initialState.userFeedback, action) => {
         ...state,
         feedback: action.payload.results,
         feedbackCount: action.payload.count,
-        isLoading: false
+        isLoading: false,
+        hasError: false
       };
     case LOAD_FEEDBACK_FAILURE:
       return {
         ...state,
-        isLoading: false
+        isLoading: false,
+        hasError: true
       };
     case LOADING_FEEDBACK:
       return {

--- a/src/components/AllocationsComponent.jsx
+++ b/src/components/AllocationsComponent.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Container, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Container, Segment, Divider, Button } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 
@@ -44,13 +44,16 @@ export class AllocationsComponent extends Component {
         </NavbarComponent>
       );
     }
-    if (!this.props.isLoading && _.isEmpty(this.props.allAllocations)) {
+    if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
           <Container>
             <h1>
-              No Assets Currently Assigned
+              An Error Occurred While Trying To Display Allocations.
             </h1>
+            <Button onClick={() => { this.props.loadAllocationsAction(this.state.activePage); }}>
+              Try Again.
+            </Button>
           </Container>
         </NavbarComponent>
       );
@@ -74,16 +77,18 @@ export class AllocationsComponent extends Component {
 
             <Table.Body>
               {
-                this.props.allAllocations.map((allocation) => {
-                  allocation.formatted_date = formatDate(allocation.created_at);
-                  return (
-                    <TableRowComponent
-                      key={allocation.created_at}
-                      data={allocation}
-                      headings={['asset', 'current_owner', 'previous_owner', 'formatted_date']}
-                    />
-                  );
-                })
+                (_.isEmpty(this.props.allAllocations))
+                ? <Table.Row><Table.Cell colSpan="4">No Assets Currently Assigned</Table.Cell></Table.Row>
+                : (this.props.allAllocations.map((allocation) => {
+                    allocation.formatted_date = formatDate(allocation.created_at);
+                    return (
+                      <TableRowComponent
+                        key={allocation.created_at}
+                        data={allocation}
+                        headings={['asset', 'current_owner', 'previous_owner', 'formatted_date']}
+                      />
+                    );
+                    }))
               }
             </Table.Body>
 
@@ -122,12 +127,13 @@ export class AllocationsComponent extends Component {
 }
 
 const mapStateToProps = ({ allocationsList }) => {
-  const { allAllocations, allocationsCount, isLoading } = allocationsList;
+  const { allAllocations, allocationsCount, isLoading, hasError } = allocationsList;
 
   return {
     allAllocations,
     allocationsCount,
-    isLoading
+    isLoading,
+    hasError
   };
 };
 
@@ -135,7 +141,8 @@ AllocationsComponent.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   allAllocations: PropTypes.array.isRequired,
   allocationsCount: PropTypes.number,
-  loadAllocationsAction: PropTypes.func.isRequired
+  loadAllocationsAction: PropTypes.func.isRequired,
+  hasError: PropTypes.bool
 };
 
 export default withRouter(connect(mapStateToProps, {

--- a/src/components/AssetCategoriesComponent.jsx
+++ b/src/components/AssetCategoriesComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { Button, Pagination, Table, Header, Segment, Divider } from 'semantic-ui-react';
+import { Button, Pagination, Table, Header, Segment, Divider, Container } from 'semantic-ui-react';
 
 import TableRowComponent from './TableRowComponent';
 import NavbarComponent from './NavBarComponent';
@@ -48,25 +48,14 @@ export class AssetCategoriesComponent extends React.Component {
     if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
-          <div className="assets-list">
+          <Container>
             <h1>
-              An Error Occurred While Trying To Display The Asset Categories
+              An Error Occurred While Trying To Display The Asset Categories.
             </h1>
             <Button onClick={() => { this.props.loadAssetCategories(this.state.activePage); }}>
               Try Again
             </Button>
-          </div>
-        </NavbarComponent>
-      );
-    }
-    if (!this.props.isLoading && this.emptyCategoriesCheck()) {
-      return (
-        <NavbarComponent>
-          <div className="assets-list">
-            <h1>
-              No Asset Categories Found.
-            </h1>
-          </div>
+          </Container>
         </NavbarComponent>
       );
     }
@@ -87,13 +76,15 @@ export class AssetCategoriesComponent extends React.Component {
 
             <Table.Body>
               {
-                this.props.categories.map(category => (
+                (this.emptyCategoriesCheck())
+                ? <Table.Row><Table.Cell colSpan="2">No Asset Categories Found</Table.Cell></Table.Row>
+                : this.props.categories.map(category => (
                   <TableRowComponent
                     key={category.id}
                     data={category}
                     headings={['id', 'category_name']}
                   />
-                ))
+                   ))
               }
             </Table.Body>
 

--- a/src/components/AssetCondition/AssetConditionsComponent.jsx
+++ b/src/components/AssetCondition/AssetConditionsComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { Table, Header, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Table, Header, Pagination, Segment, Divider, Container, Button } from 'semantic-ui-react';
 
 import TableRowComponent from '../TableRowComponent.jsx';
 import rowOptions from '../../_utils/pageRowOptions';
@@ -43,14 +43,17 @@ export class AssetConditionsComponent extends React.Component {
         </NavbarComponent>
       );
     }
-    if (!this.props.isLoading && _.isEmpty(this.props.assetConditionsList)) {
+    if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
-          <div className="assets-list">
+          <Container>
             <h1>
-              No Asset Conditions Found
+              An Error Occurred While Trying To Display The Asset Conditions.
             </h1>
-          </div>
+            <Button onClick={() => { this.props.loadAssetConditions(this.state.activePage); }}>
+              Try Again.
+            </Button>
+          </Container>
         </NavbarComponent>
       );
     }
@@ -72,16 +75,18 @@ export class AssetConditionsComponent extends React.Component {
 
             <Table.Body>
               {
-                this.props.assetConditionsList.map((assetCondition) => {
-                  assetCondition.formatted_date = formatDate(assetCondition.created_at);
-                  return (
-                    <TableRowComponent
-                      key={assetCondition.id}
-                      data={assetCondition}
-                      headings={['asset', 'asset_condition', 'formatted_date']}
-                    />
-                  );
-                })
+                (_.isEmpty(this.props.assetConditionsList))
+                ? <Table.Row><Table.Cell colSpan="3">No Asset Conditions Found</Table.Cell></Table.Row>
+                : this.props.assetConditionsList.map((assetCondition) => {
+                   assetCondition.formatted_date = formatDate(assetCondition.created_at);
+                   return (
+                     <TableRowComponent
+                       key={assetCondition.id}
+                       data={assetCondition}
+                       headings={['asset', 'asset_condition', 'formatted_date']}
+                     />
+                   );
+                   })
               }
             </Table.Body>
 
@@ -123,16 +128,18 @@ AssetConditionsComponent.propTypes = {
   assetConditionsList: PropTypes.array.isRequired,
   assetConditionsCount: PropTypes.number.isRequired,
   loadAssetConditions: PropTypes.func.isRequired,
-  isLoading: PropTypes.bool.isRequired
+  isLoading: PropTypes.bool.isRequired,
+  hasError: PropTypes.bool
 };
 
 const mapStateToProps = ({ assetConditions }) => {
-  const { assetConditionsList, assetConditionsCount, isLoading } = assetConditions;
+  const { assetConditionsList, assetConditionsCount, isLoading, hasError } = assetConditions;
 
   return {
     assetConditionsList,
     assetConditionsCount,
-    isLoading
+    isLoading,
+    hasError
   };
 };
 

--- a/src/components/AssetMake/AssetMakeComponent.jsx
+++ b/src/components/AssetMake/AssetMakeComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Segment, Divider, Container, Button } from 'semantic-ui-react';
 import _ from 'lodash';
 
 import TableRowComponent from '../TableRowComponent';
@@ -19,17 +19,17 @@ export class AssetMakeComponent extends React.Component {
   };
 
   componentDidMount() {
-    this.props.loadAssetMakes(this.state.activePage);
+    this.props.loadAssetMakes(this.state.activePage, this.state.limit);
   }
 
   handleRowChange = (e, data) => {
     this.setState({ limit: data.value });
-    this.props.loadAssetConditions(this.state.activePage, data.value);
+    this.props.loadAssetMakes(this.state.activePage, data.value);
   };
 
   handlePaginationChange = (e, { activePage }) => {
     this.setState({ activePage });
-    this.props.loadAssetMakes(activePage);
+    this.props.loadAssetMakes(activePage, this.state.limit);
   };
 
   getTotalPages = () => Math.ceil(this.props.assetMakesCount / this.state.limit);
@@ -42,14 +42,17 @@ export class AssetMakeComponent extends React.Component {
         </NavbarComponent>
       );
     }
-    if (!this.props.isLoading && _.isEmpty(this.props.assetMakes)) {
+    if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
-          <div>
+          <Container>
             <h1>
-              No Asset Make Found
+              An Error Occurred While Trying To Display The Asset Makes.
             </h1>
-          </div>
+            <Button onClick={() => { this.props.loadAssetMakes(this.state.activePage); }}>
+              Try Again.
+            </Button>
+          </Container>
         </NavbarComponent>
       );
     }
@@ -71,13 +74,15 @@ export class AssetMakeComponent extends React.Component {
 
             <Table.Body>
               {
-                this.props.assetMakes.map(asset => (
+                (_.isEmpty(this.props.assetMakes))
+                ? <Table.Row><Table.Cell colSpan="3">No Asset Make Found</Table.Cell></Table.Row>
+                : this.props.assetMakes.map(asset => (
                   <TableRowComponent
                     key={asset.id}
                     data={asset}
                     headings={['id', 'asset_type', 'make_label']}
                   />
-                ))
+                   ))
               }
             </Table.Body>
 
@@ -116,20 +121,21 @@ export class AssetMakeComponent extends React.Component {
 }
 
 const mapStateToProps = ({ assetMakesList }) => {
-  const { assetMakes, assetMakesCount, isLoading } = assetMakesList;
+  const { assetMakes, assetMakesCount, isLoading, hasError } = assetMakesList;
   return {
     assetMakes,
     assetMakesCount,
-    isLoading
+    isLoading,
+    hasError
   };
 };
 
 AssetMakeComponent.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   loadAssetMakes: PropTypes.func.isRequired,
-  loadAssetConditions: PropTypes.func.isRequired,
   assetMakes: PropTypes.array.isRequired,
-  assetMakesCount: PropTypes.number.isRequired
+  assetMakesCount: PropTypes.number.isRequired,
+  hasError: PropTypes.bool
 };
 
 export default withRouter(connect(mapStateToProps, {

--- a/src/components/AssetModels/AssetModelsComponent.jsx
+++ b/src/components/AssetModels/AssetModelsComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Segment, Divider, Container, Button } from 'semantic-ui-react';
 import _ from 'lodash';
 import TableRowComponent from '../TableRowComponent';
 import NavbarComponent from '../NavBarComponent';
@@ -44,14 +44,17 @@ export class AssetModelsComponent extends React.Component {
         </NavbarComponent>
       );
     }
-    if (!this.props.isLoading && _.isEmpty(this.props.assetModels)) {
+    if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
-          <div className="assets-list">
+          <Container>
             <h1>
-              No Asset Models Found
+              An Error Occurred While Trying To Display The Incidence Reports.
             </h1>
-          </div>
+            <Button onClick={() => { this.props.loadAssetModels(this.state.activePage); }}>
+              Try Again.
+            </Button>
+          </Container>
         </NavbarComponent>
       );
     }
@@ -74,18 +77,20 @@ export class AssetModelsComponent extends React.Component {
 
             <Table.Body>
               {
-                this.props.assetModels.map((assetModel) => {
-                  assetModel.formatted_create = formatDate(assetModel.created_at);
-                  assetModel.formatted_modified = formatDate(assetModel.last_modified);
+                (_.isEmpty(this.props.assetModels))
+                ? <Table.Row><Table.Cell colSpan="4">No Asset Models Found</Table.Cell></Table.Row>
+                : this.props.assetModels.map((assetModel) => {
+                   assetModel.formatted_create = formatDate(assetModel.created_at);
+                   assetModel.formatted_modified = formatDate(assetModel.last_modified);
 
-                  return (
-                    <TableRowComponent
-                      key={assetModel.id}
-                      data={assetModel}
-                      headings={['model_number', 'make_label', 'formatted_create', 'formatted_modified']}
-                    />
-                  );
-                })
+                   return (
+                     <TableRowComponent
+                       key={assetModel.id}
+                       data={assetModel}
+                       headings={['model_number', 'make_label', 'formatted_create', 'formatted_modified']}
+                     />
+                   );
+                   })
               }
             </Table.Body>
 
@@ -124,12 +129,13 @@ export class AssetModelsComponent extends React.Component {
 }
 
 const mapStateToProps = ({ assetModelsList }) => {
-  const { assetModels, assetModelsCount, isLoading } = assetModelsList;
+  const { assetModels, assetModelsCount, isLoading, hasError } = assetModelsList;
 
   return {
     assetModels,
     assetModelsCount,
-    isLoading
+    isLoading,
+    hasError
   };
 };
 
@@ -137,7 +143,8 @@ AssetModelsComponent.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   loadAssetModels: PropTypes.func.isRequired,
   assetModels: PropTypes.array.isRequired,
-  assetModelsCount: PropTypes.number.isRequired
+  assetModelsCount: PropTypes.number.isRequired,
+  hasError: PropTypes.bool
 };
 
 export default withRouter(connect(mapStateToProps, {

--- a/src/components/AssetSpecs/AssetSpecsComponent.jsx
+++ b/src/components/AssetSpecs/AssetSpecsComponent.jsx
@@ -43,17 +43,6 @@ export class AssetSpecsComponent extends React.Component {
         </NavbarComponent>
       );
     }
-    if (!this.props.isLoading && _.isEmpty(this.props.specs)) {
-      return (
-        <NavbarComponent>
-          <div className="assets-list">
-            <h1>
-              No Asset Spec Found
-            </h1>
-          </div>
-        </NavbarComponent>
-      );
-    }
     if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
@@ -87,21 +76,23 @@ export class AssetSpecsComponent extends React.Component {
 
             <Table.Body>
               {
-                this.props.specs.map(spec => (
+                (_.isEmpty(this.props.specs))
+                ? <Table.Row><Table.Cell colSpan="7">No Asset Spec Found</Table.Cell></Table.Row>
+                : this.props.specs.map(spec => (
                   <TableRowComponent
                     key={spec.id}
                     data={spec}
                     headings={[
-                      'id',
-                      'year_of_manufacture',
-                      'processor_speed',
-                      'screen_size',
-                      'processor_type',
-                      'storage',
-                      'memory'
-                    ]}
+                       'id',
+                       'year_of_manufacture',
+                       'processor_speed',
+                       'screen_size',
+                       'processor_type',
+                       'storage',
+                       'memory'
+                     ]}
                   />
-                ))
+                   ))
               }
             </Table.Body>
 

--- a/src/components/AssetTypesComponent.jsx
+++ b/src/components/AssetTypesComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Segment, Divider, Button, Container } from 'semantic-ui-react';
 import _ from 'lodash';
 
 import TableRowComponent from './TableRowComponent';
@@ -44,14 +44,17 @@ export class AssetTypesComponent extends React.Component {
         </NavbarComponent>
       );
     }
-    if (!this.props.isLoading && _.isEmpty(this.props.assetTypes)) {
+    if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
-          <div>
+          <Container>
             <h1>
-              No Asset Types Found
+              An Error Occurred While Trying To Display The Asset Types.
             </h1>
-          </div>
+            <Button onClick={() => { this.props.loadAssetTypes(this.state.activePage); }}>
+              Try Again.
+            </Button>
+          </Container>
         </NavbarComponent>
       );
     }
@@ -72,13 +75,15 @@ export class AssetTypesComponent extends React.Component {
 
             <Table.Body>
               {
-                this.props.assetTypes.map(assetType => (
+                (_.isEmpty(this.props.assetTypes))
+                ? <Table.Row><Table.Cell colSpan="2">No Asset Types Found</Table.Cell></Table.Row>
+                : this.props.assetTypes.map(assetType => (
                   <TableRowComponent
                     key={assetType.id}
                     data={assetType}
                     headings={['asset_sub_category', 'asset_type']}
                   />
-                ))
+                   ))
               }
             </Table.Body>
 
@@ -117,11 +122,12 @@ export class AssetTypesComponent extends React.Component {
 }
 
 const mapStateToProps = ({ assetTypesList }) => {
-  const { assetTypes, assetTypesCount, isLoading } = assetTypesList;
+  const { assetTypes, assetTypesCount, isLoading, hasError } = assetTypesList;
   return {
     assetTypes,
     assetTypesCount,
-    isLoading
+    isLoading,
+    hasError
   };
 };
 
@@ -129,7 +135,8 @@ AssetTypesComponent.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   loadAssetTypes: PropTypes.func.isRequired,
   assetTypes: PropTypes.array.isRequired,
-  assetTypesCount: PropTypes.number.isRequired
+  assetTypesCount: PropTypes.number.isRequired,
+  hasError: PropTypes.bool
 };
 
 export default withRouter(connect(mapStateToProps, {

--- a/src/components/AssetsSubCategoriesComponent.jsx
+++ b/src/components/AssetsSubCategoriesComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Segment, Divider, Container, Button } from 'semantic-ui-react';
 import _ from 'lodash';
 
 import TableRowComponent from './TableRowComponent';
@@ -43,14 +43,17 @@ export class AssetSubCategoriesComponent extends React.Component {
         </NavbarComponent>
       );
     }
-    if (!this.props.isLoading && _.isEmpty(this.props.assetSubCategories)) {
+    if (!this.props.isLoading && this.props.hasError) {
       return (
         <NavbarComponent>
-          <div className="">
+          <Container>
             <h1>
-              No Asset Sub Category Found
+              An Error Occurred While Trying To Display The Asset SubCategories.
             </h1>
-          </div>
+            <Button onClick={() => { this.props.loadSubCategories(this.state.activePage); }}>
+              Try Again.
+            </Button>
+          </Container>
         </NavbarComponent>
       );
     }
@@ -72,13 +75,15 @@ export class AssetSubCategoriesComponent extends React.Component {
 
             <Table.Body>
               {
-                this.props.assetSubCategories.map(subCategory => (
+                (_.isEmpty(this.props.assetSubCategories))
+                ? <Table.Row><Table.Cell colSpan="3">No Asset Sub Category Found</Table.Cell></Table.Row>
+                : this.props.assetSubCategories.map(subCategory => (
                   <TableRowComponent
                     key={subCategory.id}
                     data={subCategory}
                     headings={['id', 'sub_category_name', 'asset_category']}
                   />
-                ))
+                   ))
               }
             </Table.Body>
 
@@ -117,11 +122,12 @@ export class AssetSubCategoriesComponent extends React.Component {
 }
 
 const mapStateToProps = ({ subcategoriesList }) => {
-  const { assetSubCategories, assetSubCategoriesCount, isLoading } = subcategoriesList;
+  const { assetSubCategories, assetSubCategoriesCount, isLoading, hasError } = subcategoriesList;
   return {
     assetSubCategories,
     assetSubCategoriesCount,
-    isLoading
+    isLoading,
+    hasError
   };
 };
 
@@ -129,7 +135,8 @@ AssetSubCategoriesComponent.propTypes = {
   isLoading: PropTypes.bool.isRequired,
   loadSubCategories: PropTypes.func.isRequired,
   assetSubCategories: PropTypes.array.isRequired,
-  assetSubCategoriesCount: PropTypes.number.isRequired
+  assetSubCategoriesCount: PropTypes.number.isRequired,
+  hasError: PropTypes.bool
 };
 
 export default withRouter(connect(mapStateToProps, {

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -1,6 +1,5 @@
 import React from 'react';
 import {
-  Header,
   Table,
   Pagination,
   Segment
@@ -29,12 +28,6 @@ const AssetsTableContent = (props) => {
       ToastMessage.error({ message: props.errorMessage });
     }, 500);
     return <SemanticToastContainer />;
-  }
-
-  if (props.emptyAssetsCheck()) {
-    return (
-      <Header as="h3" id="empty-assets" content="No Assets Found" />
-    );
   }
 
   return (
@@ -83,26 +76,28 @@ const AssetsTableContent = (props) => {
 
         <Table.Body>
           {
-            props.activePageAssets.map((asset) => {
-              const assetViewUrl = `assets/${asset.serial_number}/view`;
-              return (
-                <TableRowComponent
-                  {...props}
-                  viewDetailsRoute={assetViewUrl}
-                  key={asset.id}
-                  data={asset}
-                  headings={[
-                    'asset_code',
-                    'serial_number',
-                    'model_number',
-                    'make_label',
-                    'asset_type',
-                    'asset_category',
-                    'asset_sub_category'
-                  ]}
-                />
-              );
-            })
+            (props.emptyAssetsCheck())
+            ? <Table.Row><Table.Cell colSpan="7">No Assets Found</Table.Cell></Table.Row>
+            : props.activePageAssets.map((asset) => {
+               const assetViewUrl = `assets/${asset.serial_number}/view`;
+               return (
+                 <TableRowComponent
+                   {...props}
+                   viewDetailsRoute={assetViewUrl}
+                   key={asset.id}
+                   data={asset}
+                   headings={[
+                     'asset_code',
+                     'serial_number',
+                     'model_number',
+                     'make_label',
+                     'asset_type',
+                     'asset_category',
+                     'asset_sub_category'
+                   ]}
+                 />
+               );
+               })
           }
         </Table.Body>
 

--- a/src/components/IncidenceReportsComponent.jsx
+++ b/src/components/IncidenceReportsComponent.jsx
@@ -2,12 +2,13 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import _ from 'lodash';
 import { connect } from 'react-redux';
-import { Table, Header, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Table, Header, Pagination, Segment, Divider, Container, Button } from 'semantic-ui-react';
 
 import TableRowComponent from './TableRowComponent.jsx';
 import NavbarComponent from './NavBarComponent';
 import rowOptions from '../_utils/pageRowOptions';
 import DropdownComponent from '../components/common/DropdownComponent';
+import LoaderComponent from './LoaderComponent';
 import { loadIncidenceReports } from '../_actions/incidenceReports.actions';
 import '../_css/IncidenceReportsComponent.css';
 
@@ -36,6 +37,27 @@ export class IncidenceReportsComponent extends React.Component {
   emptyReportsCheck = () => (_.isEmpty(this.props.reports))
 
   render() {
+    if (this.props.isLoading) {
+      return (
+        <NavbarComponent>
+          <LoaderComponent size="large" dimmerStyle={{ height: '90vh' }} />
+        </NavbarComponent>
+      );
+    }
+    if (!this.props.isLoading && this.props.hasError) {
+      return (
+        <NavbarComponent>
+          <Container>
+            <h1>
+              An Error Occurred While Trying To Display The Incidence Reports.
+            </h1>
+            <Button onClick={() => { this.props.loadIncidenceReports(this.state.activePage); }}>
+              Try Again.
+            </Button>
+          </Container>
+        </NavbarComponent>
+      );
+    }
     return (
       <NavbarComponent>
         <div className="incidence-list">
@@ -117,14 +139,18 @@ export class IncidenceReportsComponent extends React.Component {
 IncidenceReportsComponent.propTypes = {
   reports: PropTypes.array,
   incidenceReportsCount: PropTypes.number,
-  loadIncidenceReports: PropTypes.func
+  loadIncidenceReports: PropTypes.func,
+  isLoading: PropTypes.bool,
+  hasError: PropTypes.bool
 };
 
 const mapStateToProps = ({ incidenceReports }) => {
-  const { incidenceReportsCount, reports } = incidenceReports;
+  const { incidenceReportsCount, reports, isLoading, hasError } = incidenceReports;
   return {
     incidenceReportsCount,
-    reports
+    reports,
+    isLoading,
+    hasError
   };
 };
 

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -163,7 +163,7 @@ export class NavBarComponent extends Component {
                       </Grid.Column>
 
                       <Grid.Column>
-                        <Link to="/asset_makes"><Icon name="list ul" />Asset Makes</Link>
+                        <Link to="/asset-makes"><Icon name="list ul" />Asset Makes</Link>
                       </Grid.Column>
 
                       <Grid.Column>

--- a/src/components/User/UserComponent.jsx
+++ b/src/components/User/UserComponent.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Table, Header, Pagination, Segment } from 'semantic-ui-react';
+import { Table, Pagination, Segment } from 'semantic-ui-react';
 import { SemanticToastContainer } from 'react-semantic-toasts';
 import rowOptions from '../../_utils/pageRowOptions';
 import DropdownComponent from '../common/DropdownComponent';
@@ -18,12 +18,6 @@ const UserComponent = (props) => {
       ToastMessage.error({ message: props.errorMessage });
     }, 500);
     return <SemanticToastContainer />;
-  }
-
-  if (props.emptyUsersList()) {
-    return (
-      <Header as="h3" id="empty-usersList" content="No Users Found" />
-    );
   }
 
   return (
@@ -47,21 +41,23 @@ const UserComponent = (props) => {
         </Table.Header>
         <Table.Body>
           {
-            props.activePageUsers.map((user) => {
-              user.assets_assigned = 1;
-              return (
-                <TableRowComponent
-                  key={user.id}
-                  data={user}
-                  headings={[
-                    'full_name',
-                    'email',
-                    'cohort',
-                    'assets_assigned'
-                  ]}
-                />
-              );
-            })
+            (props.emptyUsersList())
+            ? <Table.Row><Table.Cell colSpan="4">No Users Found</Table.Cell></Table.Row>
+            : props.activePageUsers.map((user) => {
+               user.assets_assigned = 1;
+               return (
+                 <TableRowComponent
+                   key={user.id}
+                   data={user}
+                   headings={[
+                     'full_name',
+                     'email',
+                     'cohort',
+                     'assets_assigned'
+                   ]}
+                 />
+               );
+               })
           }
         </Table.Body>
         <Table.Footer>

--- a/src/components/User/UserFeedbackComponent.jsx
+++ b/src/components/User/UserFeedbackComponent.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Segment, Divider, Container, Button } from 'semantic-ui-react';
 import _ from 'lodash';
 
 import feedbackAction from '../../_actions/userFeedback.actions';
@@ -43,20 +43,25 @@ export class UserFeedbackComponent extends React.Component {
   render() {
     if (this.props.isLoading) {
       return (
-        <LoaderComponent size="small" dimmerStyle={{ height: '100vh' }} />
-      );
-    }
-
-    if (!this.props.isLoading && this.props.feedbackCount <= 0) {
-      return (
         <NavbarComponent>
-          <div className="">
-            <h1>No Feedback Found</h1>
-          </div>
+          <LoaderComponent size="small" dimmerStyle={{ height: '100vh' }} />
         </NavbarComponent>
       );
     }
-
+    if (!this.props.isLoading && this.props.hasError) {
+      return (
+        <NavbarComponent>
+          <Container>
+            <h1>
+              An Error Occurred While Trying To Display User Feedback.
+            </h1>
+            <Button onClick={() => { this.props.feedbackAction(this.state.activePage); }}>
+              Try Again.
+            </Button>
+          </Container>
+        </NavbarComponent>
+      );
+    }
     return (
       <NavbarComponent title="User Feedback">
         <div className="feedback-list">
@@ -76,20 +81,22 @@ export class UserFeedbackComponent extends React.Component {
             />
             <Table.Body>
               {
-                this.props.feedback.map((feedback, index) => (
+                (_.isEmpty(this.props.feedback))
+                ? <Table.Row><Table.Cell colSpan="5">No Feedback Found</Table.Cell></Table.Row>
+                : this.props.feedback.map((feedback, index) => (
                   <TableRowComponent
-                    key={index} //eslint-disable-line
+                      key={index} //eslint-disable-line
                     data={feedback}
                     headings={['reported_by',
-                      'created_at',
-                      'report_type',
-                      'message']}
+                        'created_at',
+                        'report_type',
+                        'message']}
                   >
                     <Table.Cell>
                       <ActionComponent />
                     </Table.Cell>
                   </TableRowComponent>
-                ))
+                    ))
               }
             </Table.Body>
 
@@ -130,11 +137,12 @@ export class UserFeedbackComponent extends React.Component {
 }
 
 const mapStateToProps = ({ feedbackReducer }) => {
-  const { feedback, feedbackCount, isLoading } = feedbackReducer;
+  const { feedback, feedbackCount, isLoading, hasError } = feedbackReducer;
   return {
     feedback,
     feedbackCount,
-    isLoading
+    isLoading,
+    hasError
   };
 };
 
@@ -142,7 +150,8 @@ UserFeedbackComponent.propTypes = {
   feedbackAction: PropTypes.func,
   feedback: PropTypes.arrayOf(PropTypes.object),
   feedbackCount: PropTypes.number,
-  isLoading: PropTypes.bool
+  isLoading: PropTypes.bool,
+  hasError: PropTypes.bool
 };
 
 UserFeedbackComponent.defaultProps = {


### PR DESCRIPTION
## What does this PR do?
Ensures that a table is always displayed regardless of whether there is content or not.

## Description of Task to be completed?
- Refactor relevant components to ensure tables are always displayed
- Refactor relevant tests

## How should this be manually tested?
- On the navigation bar, once you click on either `users`, `assets`, `allocations`, `reports` or `feedback`, a table should be displayed regardless of whether there is any content.

## What are the relevant pivotal tracker stories?
[#159470729](https://www.pivotaltracker.com/n/projects/2146417/stories/159470729)

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
<img width="1400" alt="screen shot 2018-08-14 at 22 33 42" src="https://user-images.githubusercontent.com/31322228/44113960-6ad7ea04-a012-11e8-8b0b-839bc6b1f8ec.png">
<img width="1374" alt="screen shot 2018-08-14 at 22 35 29" src="https://user-images.githubusercontent.com/31322228/44113973-722b70a0-a012-11e8-9df0-88f62bb4e413.png">

