### PR TITLE
#159519715  Field Validation On Asset Modal

### DIFF
--- a/src/_components/Assets/AddAssetContainer.jsx
+++ b/src/_components/Assets/AddAssetContainer.jsx
@@ -97,14 +97,13 @@ class AddAssetContainer extends React.Component {
 
   pageValidator = () => {
     if (this.state.page === 0) {
-      return (!_.isEmpty(this.state.selectedAssetMake));
-    } else if (this.state.page === 1) {
-      return (!_.isEmpty(this.state.modelNumber)
-        && !_.isEmpty(this.state.serialNumber)
-        && !_.isEmpty(this.state.assetTag)
-      );
+      return (_.isEmpty(this.state.selectedAssetMake));
     }
-    return false;
+    return (
+      _.isEmpty(this.state.modelNumber) ||
+      _.isEmpty(this.state.serialNumber) ||
+      _.isEmpty(this.state.assetTag)
+    );
   }
 
   handleDropdownChanges = (event, data) => {
@@ -192,6 +191,8 @@ class AddAssetContainer extends React.Component {
   };
 
   render() {
+    const isDisabled = this.pageValidator();
+
     if (this.state.page === 1) {
       return (
         <AddAssetComponent
@@ -210,7 +211,7 @@ class AddAssetContainer extends React.Component {
           selectedAssetType={this.state.selectedAssetType}
           buttonState={this.state.saveButtonState}
           onChangeButtonState={this.onChangeButtonState}
-          pageValidator={this.pageValidator}
+          isDisabled={isDisabled}
         />
       );
     } else if (this.state.page === 2) {
@@ -239,7 +240,7 @@ class AddAssetContainer extends React.Component {
         selectedSubcategory={this.state.selectedSubcategory}
         selectedAssetType={this.state.selectedAssetType}
         selectedAssetMake={this.state.selectedAssetMake}
-        pageValidator={this.pageValidator}
+        isDisabled={isDisabled}
         onNextClicked={this.onNextClicked}
       />
     );

--- a/src/_components/Assets/AddAssetContainer.jsx
+++ b/src/_components/Assets/AddAssetContainer.jsx
@@ -95,6 +95,18 @@ class AddAssetContainer extends React.Component {
     return null;
   }
 
+  pageValidator = () => {
+    if (this.state.page === 0) {
+      return (!_.isEmpty(this.state.selectedAssetMake));
+    } else if (this.state.page === 1) {
+      return (!_.isEmpty(this.state.modelNumber)
+        && !_.isEmpty(this.state.serialNumber)
+        && !_.isEmpty(this.state.assetTag)
+      );
+    }
+    return false;
+  }
+
   handleDropdownChanges = (event, data) => {
     event.stopPropagation();
     const { name, value } = data;
@@ -103,6 +115,9 @@ class AddAssetContainer extends React.Component {
     if (name === 'asset-category') {
       this.setState({
         selectedCategory: value,
+        selectedSubcategory: '',
+        selectedAssetType: '',
+        selectedAssetMake: '',
         filteredSubCategories: filterSubCategories(subcategories, value),
         filteredAssetTypes: filterAssetTypes(assetTypes, value),
         filteredAssetMakes: filterAssetMakes(assetMakes, value),
@@ -111,6 +126,8 @@ class AddAssetContainer extends React.Component {
     } else if (name === 'asset-subcategory') {
       this.setState({
         selectedSubcategory: value,
+        selectedAssetType: '',
+        selectedAssetMake: '',
         filteredAssetTypes: filterAssetTypes(assetTypes, value),
         filteredAssetMakes: filterAssetMakes(assetMakes, value),
         filteredModelNumbers: filterModelNumbers(modelNumbers, value)
@@ -118,12 +135,14 @@ class AddAssetContainer extends React.Component {
     } else if (name === 'asset-types') {
       this.setState({
         selectedAssetType: value,
+        selectedAssetMake: '',
         filteredAssetMakes: filterAssetMakes(assetMakes, value),
         filteredModelNumbers: filterModelNumbers(modelNumbers, value)
       });
     } else if (name === 'asset-makes') {
       this.setState({
         selectedAssetMake: value,
+        modelNumber: '',
         filteredModelNumbers: filterModelNumbers(modelNumbers, value)
       });
     }
@@ -191,6 +210,7 @@ class AddAssetContainer extends React.Component {
           selectedAssetType={this.state.selectedAssetType}
           buttonState={this.state.saveButtonState}
           onChangeButtonState={this.onChangeButtonState}
+          pageValidator={this.pageValidator}
         />
       );
     } else if (this.state.page === 2) {
@@ -219,6 +239,7 @@ class AddAssetContainer extends React.Component {
         selectedSubcategory={this.state.selectedSubcategory}
         selectedAssetType={this.state.selectedAssetType}
         selectedAssetMake={this.state.selectedAssetMake}
+        pageValidator={this.pageValidator}
         onNextClicked={this.onNextClicked}
       />
     );

--- a/src/_components/Assets/AddAssetContainer.jsx
+++ b/src/_components/Assets/AddAssetContainer.jsx
@@ -114,8 +114,6 @@ class AddAssetContainer extends React.Component {
     if (name === 'asset-category') {
       this.setState({
         selectedCategory: value,
-        selectedSubcategory: '',
-        selectedAssetType: '',
         selectedAssetMake: '',
         filteredSubCategories: filterSubCategories(subcategories, value),
         filteredAssetTypes: filterAssetTypes(assetTypes, value),
@@ -125,7 +123,6 @@ class AddAssetContainer extends React.Component {
     } else if (name === 'asset-subcategory') {
       this.setState({
         selectedSubcategory: value,
-        selectedAssetType: '',
         selectedAssetMake: '',
         filteredAssetTypes: filterAssetTypes(assetTypes, value),
         filteredAssetMakes: filterAssetMakes(assetMakes, value),

--- a/src/components/Assets/AddAssetComponent.jsx
+++ b/src/components/Assets/AddAssetComponent.jsx
@@ -21,8 +21,6 @@ const specsComponentCheck = (userDefinedassetType) => {
   return false;
 };
 
-const isEnabled = props => props();
-
 const AddAssetComponent = props => (
   <div className="modal-container">
     <div className="page-indicator">
@@ -77,7 +75,7 @@ const AddAssetComponent = props => (
             buttonName="Next"
             color="primary"
             handleClick={props.onNextClicked}
-            disabledState={!isEnabled(props.pageValidator)}
+            disabledState={props.isDisabled}
           />
           :
           <ArtButton
@@ -86,7 +84,7 @@ const AddAssetComponent = props => (
             color="primary"
             handleClick={props.onChangeButtonState}
             buttonState={props.buttonState}
-            disabledState={!isEnabled(props.pageValidator)}
+            disabledState={props.isDisabled}
           />
       }
     </Form>
@@ -103,7 +101,7 @@ AddAssetComponent.propTypes = {
   onChangeButtonState: PropTypes.func.isRequired,
   onNextClicked: PropTypes.func.isRequired,
   selectedAssetType: PropTypes.string.isRequired,
-  pageValidator: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool.isRequired,
   buttonState: PropTypes.bool,
   page: PropTypes.number,
   modelNumber: PropTypes.string,

--- a/src/components/Assets/AddAssetComponent.jsx
+++ b/src/components/Assets/AddAssetComponent.jsx
@@ -21,6 +21,8 @@ const specsComponentCheck = (userDefinedassetType) => {
   return false;
 };
 
+const isEnabled = props => props();
+
 const AddAssetComponent = props => (
   <div className="modal-container">
     <div className="page-indicator">
@@ -75,6 +77,7 @@ const AddAssetComponent = props => (
             buttonName="Next"
             color="primary"
             handleClick={props.onNextClicked}
+            disabledState={!isEnabled(props.pageValidator)}
           />
           :
           <ArtButton
@@ -83,6 +86,7 @@ const AddAssetComponent = props => (
             color="primary"
             handleClick={props.onChangeButtonState}
             buttonState={props.buttonState}
+            disabledState={!isEnabled(props.pageValidator)}
           />
       }
     </Form>
@@ -99,6 +103,7 @@ AddAssetComponent.propTypes = {
   onChangeButtonState: PropTypes.func.isRequired,
   onNextClicked: PropTypes.func.isRequired,
   selectedAssetType: PropTypes.string.isRequired,
+  pageValidator: PropTypes.func.isRequired,
   buttonState: PropTypes.bool,
   page: PropTypes.number,
   modelNumber: PropTypes.string,
@@ -114,7 +119,8 @@ AddAssetComponent.defaultTypes = {
   buttonState: false,
   page: 1,
   assetTag: '',
-  serialNumber: ''
+  serialNumber: '',
+  modelNumber: ''
 };
 
 export default AddAssetComponent;

--- a/src/components/Assets/FilterAssetComponent.js
+++ b/src/components/Assets/FilterAssetComponent.js
@@ -86,6 +86,7 @@ const FilterAssetComponent = (props) => {
         color="primary"
         handleClick={props.onNextClicked}
         buttonState={props.buttonState}
+        disabledState={props.isDisabled}
       />
     </div>
   );
@@ -98,7 +99,7 @@ FilterAssetComponent.propTypes = {
   filteredAssetMakes: PropTypes.array,
   toggleModal: PropTypes.func.isRequired,
   onNextClicked: PropTypes.func.isRequired,
-  pageValidator: PropTypes.func.isRequired,
+  isDisabled: PropTypes.bool.isRequired,
   categories: PropTypes.array,
   page: PropTypes.number.isRequired,
   selectedCategory: PropTypes.string,

--- a/src/components/Assets/FilterAssetComponent.js
+++ b/src/components/Assets/FilterAssetComponent.js
@@ -98,7 +98,7 @@ FilterAssetComponent.propTypes = {
   filteredAssetMakes: PropTypes.array,
   toggleModal: PropTypes.func.isRequired,
   onNextClicked: PropTypes.func.isRequired,
-  buttonState: PropTypes.bool,
+  pageValidator: PropTypes.func.isRequired,
   categories: PropTypes.array,
   page: PropTypes.number.isRequired,
   selectedCategory: PropTypes.string,
@@ -113,8 +113,7 @@ FilterAssetComponent.defaultTypes = {
   filteredAssetTypes: [],
   filteredAssetMakes: [],
   filteredModelNumbers: [],
-  categories: [],
-  buttonState: false
+  categories: []
 };
 
 export default FilterAssetComponent;


### PR DESCRIPTION
## What does this PR do?
- Disallow the user from continue/clicking `Next` without filling in Category, Subcategory, Asset Type and Asset Make
- Disallow the user from saving without filling model number, asset tag and serial number
## Description of Task to be completed?
- use disabled attribute in Button component
- add function to check which page is being validated
- add button disable when user has not filled in fields in form.
## How should this be manually tested?
- `npm test` OR 
- Login, click on `ADD ASSET` on the navbar
- The `NEXT` button is disabled by default.
- Fill in the Category, Subcategory, Asset Type and Asset Make. The `NEXT` button will be enabled. If you change any these, Category, Subcategory, Asset Type and Asset Make and some fields become empty then the `NEXT` button is disabled. This is the same for page 2, `Fill out device specs`
## What are the relevant pivotal tracker stories?
[#159519715](https://www.pivotaltracker.com/story/show/159519715)
## Any background context you want to add?
n/a
## Important notes
n/a
## Packages installed
n/a
## Deployment note
n/a
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [x] Test
- [ ] Documentation
## Screenshots
![screen shot 2018-08-17 at 13 22 43](https://user-images.githubusercontent.com/6042152/44261603-d9b57080-a220-11e8-866d-3fadc04f9a05.png)
![screen shot 2018-08-17 at 13 23 11](https://user-images.githubusercontent.com/6042152/44261604-d9b57080-a220-11e8-9759-e6c9fff5ede6.png)
![screen shot 2018-08-17 at 13 23 24](https://user-images.githubusercontent.com/6042152/44261605-da4e0700-a220-11e8-85c6-098ef01bb8c4.png)
![screen shot 2018-08-17 at 13 23 44](https://user-images.githubusercontent.com/6042152/44261606-da4e0700-a220-11e8-9b2d-11cdedde0471.png)
![screen shot 2018-08-17 at 13 24 00](https://user-images.githubusercontent.com/6042152/44261607-da4e0700-a220-11e8-86eb-478374311c02.png)