### PR TITLE
#159958261 Change url from serial number to asset id

### DIFF
--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -84,7 +84,7 @@ const AssetsTableContent = (props) => {
         <Table.Body>
           {
             props.activePageAssets.map((asset) => {
-              const assetViewUrl = `assets/${asset.serial_number}/view`;
+              const assetViewUrl = `assets/${asset.id}/view`;
 
               const updatedAsset = {
                 ...asset,


### PR DESCRIPTION
## What does this PR do?
- change the url to use the asset id instead of asset serial number
## Description of Task to be completed?
- change the `AssetsTableContent` component to use asset `id` instead of `serial_number`
## How should this be manually tested?
- Login to ART, 
- Go to asset list page.
- Click on an asset. The url should be a number and not a alphanumeric text
`assets/{id}/view` e.g. `assets/154/view`
## What are the relevant pivotal tracker stories?
[#159958261](https://www.pivotaltracker.com/story/show/159958261)
## Any background context you want to add?
n/a
## Important notes
n/a
## Packages installed
n/a
## Deployment note
n/a
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots