### PR TITLE
#159958261 Change to uuid instead of asset id on url

### DIFF
--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -84,7 +84,7 @@ const AssetsTableContent = (props) => {
         <Table.Body>
           {
             props.activePageAssets.map((asset) => {
-              const assetViewUrl = `assets/${asset.id}/view`;
+              const assetViewUrl = `assets/${asset.uuid}/view`;
 
               const updatedAsset = {
                 ...asset,


### PR DESCRIPTION
## What does this PR do?
- change the url to use the uuid instead of asset id
## Description of Task to be completed?
- change the `AssetsTableContent` component to use asset `uuid` instead of `id`
## How should this be manually tested?
- Login to ART, 
- Go to asset list page.
- Click on an asset.
`assets/{uuid}/view` e.g. `assets/c0b8e495-0d7b-435a-a36e-83b79e3453e8/view`
## What are the relevant pivotal tracker stories?
[#159958261](https://www.pivotaltracker.com/story/show/159958261)
## Important notes
n/a
## Packages installed
n/a
## Deployment note
n/a
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots