### PR TITLE
#159880567 Remove plus icons in assets list page

### DIFF
--- a/src/_css/sharedStyling.scss
+++ b/src/_css/sharedStyling.scss
@@ -62,6 +62,11 @@ input,
   @include blue-rounded-buttons
 }
 
+.ui.medium.button.add-asset {
+  @include blue-rounded-buttons;
+  width: 14.5em;
+}
+
 #page-heading-section {
   height: 77px;
   margin-top: 45px;
@@ -250,4 +255,11 @@ input,
 
 .ui.fluid {
   margin-top: 10px;
+}
+
+.header-modal-button {
+  display: flex;
+  align-self: flex-end;
+  float:right;
+  margin-bottom: 10%;
 }

--- a/src/_css/sharedStyling.scss
+++ b/src/_css/sharedStyling.scss
@@ -260,6 +260,6 @@ input,
 .header-modal-button {
   display: flex;
   align-self: flex-end;
-  float:right;
+  float: right;
   margin-bottom: 10%;
 }

--- a/src/components/AssetCategoriesComponent.jsx
+++ b/src/components/AssetCategoriesComponent.jsx
@@ -9,6 +9,8 @@ import NavbarComponent from './NavBarComponent';
 import rowOptions from '../_utils/pageRowOptions';
 import DropdownComponent from '../components/common/DropdownComponent';
 import LoaderComponent from './LoaderComponent';
+import ModalComponent from './common/ModalComponent';
+import CategoryContainer from '../_components/Category/CategoryContainer';
 
 import '../_css/AssetsComponent.css';
 import { loadAssetCategories } from '../_actions/assetCategories.actions';
@@ -76,6 +78,21 @@ export class AssetCategoriesComponent extends React.Component {
           <div id="page-heading-section">
             <Header as="h1" id="page-headings" floated="left" content="Asset Categories" />
             <Divider id="assets-divider" />
+            <div className="header-modal-button">
+              <ModalComponent
+                trigger={
+                  <Button
+                    className="add-asset"
+                    size="small"
+                  >
+                    ADD CATEGORY
+                  </Button>
+                }
+                modalTitle="Add Asset Category"
+              >
+                <CategoryContainer />
+              </ModalComponent>
+            </div>
           </div>
           <Table basic selectable>
             <Table.Header>

--- a/src/components/AssetMake/AssetMakeComponent.jsx
+++ b/src/components/AssetMake/AssetMakeComponent.jsx
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import {
+  Header,
+  Table,
+  Pagination,
+  Segment,
+  Divider,
+  Button
+} from 'semantic-ui-react';
 import _ from 'lodash';
 
 import TableRowComponent from '../TableRowComponent';
@@ -11,6 +18,8 @@ import DropdownComponent from '../../_components/DropdownComponent';
 import LoaderComponent from '../../components/LoaderComponent';
 import { loadAssetMakes } from '../../_actions/assetMakes.actions';
 import rowOptions from '../../_utils/pageRowOptions';
+import ModalComponent from '../common/ModalComponent';
+import AssetMakeContainer from '../../_components/AssetMake/AssetMakeContainer';
 
 export class AssetMakeComponent extends React.Component {
   state = {
@@ -59,6 +68,21 @@ export class AssetMakeComponent extends React.Component {
           <div id="page-heading-section">
             <Header as="h1" id="page-headings" floated="left" content="Asset Makes" />
             <Divider id="assets-divider" />
+            <div className="header-modal-button">
+              <ModalComponent
+                trigger={
+                  <Button
+                    className="add-asset"
+                    size="medium"
+                  >
+                    ADD ASSET MAKE
+                  </Button>
+                }
+                modalTitle="Add Asset Make"
+              >
+                <AssetMakeContainer />
+              </ModalComponent>
+            </div>
           </div>
           <Table basic>
             <Table.Header>

--- a/src/components/AssetModels/AssetModelsComponent.jsx
+++ b/src/components/AssetModels/AssetModelsComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Segment, Divider, Button } from 'semantic-ui-react';
 import _ from 'lodash';
 import TableRowComponent from '../TableRowComponent';
 import NavbarComponent from '../NavBarComponent';
@@ -10,6 +10,8 @@ import rowOptions from '../../_utils/pageRowOptions';
 import DropdownComponent from '../../components/common/DropdownComponent';
 import LoaderComponent from '../../components/LoaderComponent';
 import formatDate from '../../_utils/dateFormatter';
+import ModalComponent from '../common/ModalComponent';
+import ModelNumberContainer from '../../_components/ModelNumber/ModelNumberContainer';
 
 import { loadAssetModels } from '../../_actions/assetModels.action';
 import '../../_css/AssetsComponent.css';
@@ -61,6 +63,21 @@ export class AssetModelsComponent extends React.Component {
           <div id="page-heading-section">
             <Header as="h1" id="page-headings" floated="left" content="Asset Models" />
             <Divider id="assets-divider" />
+            <div className="header-modal-button">
+              <ModalComponent
+                trigger={
+                  <Button
+                    className="add-asset"
+                    size="medium"
+                  >
+                    ADD MODEL NUMBER
+                  </Button>
+                }
+                modalTitle="Add Model Number"
+              >
+                <ModelNumberContainer />
+              </ModalComponent>
+            </div>
           </div>
           <Table basic selectable>
             <Table.Header>

--- a/src/components/AssetTypesComponent.jsx
+++ b/src/components/AssetTypesComponent.jsx
@@ -2,7 +2,7 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import { Header, Table, Pagination, Segment, Divider, Button } from 'semantic-ui-react';
 import _ from 'lodash';
 
 import TableRowComponent from './TableRowComponent';
@@ -10,6 +10,8 @@ import rowOptions from '../_utils/pageRowOptions';
 import NavbarComponent from './NavBarComponent';
 import DropdownComponent from '../components/common/DropdownComponent';
 import LoaderComponent from '../components/LoaderComponent';
+import AssetTypesContainer from '../_components/AssetTypes/AddAssetTypesContainer';
+import ModalComponent from './common/ModalComponent';
 
 import '../_css/AssetsComponent.css';
 import { loadAssetTypes } from '../_actions/assetTypes.actions';
@@ -61,6 +63,21 @@ export class AssetTypesComponent extends React.Component {
           <div id="page-heading-section">
             <Header as="h1" id="page-headings" floated="left" content="Asset Types" />
             <Divider id="assets-divider" />
+            <div className="header-modal-button">
+              <ModalComponent
+                trigger={
+                  <Button
+                    className="add-asset"
+                    size="small"
+                  >
+                    ADD ASSET TYPE
+                  </Button>
+                }
+                modalTitle="Add Asset Type"
+              >
+                <AssetTypesContainer />
+              </ModalComponent>
+            </div>
           </div>
           <Table basic selectable>
             <Table.Header>

--- a/src/components/AssetsSubCategoriesComponent.jsx
+++ b/src/components/AssetsSubCategoriesComponent.jsx
@@ -2,7 +2,14 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import { connect } from 'react-redux';
 import { withRouter } from 'react-router-dom';
-import { Header, Table, Pagination, Segment, Divider } from 'semantic-ui-react';
+import {
+  Header,
+  Table,
+  Pagination,
+  Segment,
+  Divider,
+  Button
+} from 'semantic-ui-react';
 import _ from 'lodash';
 
 import TableRowComponent from './TableRowComponent';
@@ -10,6 +17,8 @@ import NavbarComponent from './NavBarComponent';
 import rowOptions from '../_utils/pageRowOptions';
 import DropdownComponent from '../components/common/DropdownComponent';
 import LoaderComponent from '../components/LoaderComponent';
+import ModalComponent from './common/ModalComponent';
+import AddSubCategoryContainer from '../_components/SubCategory/AddSubCategoriesContainer';
 import '../_css/AssetsComponent.css';
 import { loadSubCategories } from '../_actions/subcategory.actions';
 
@@ -60,6 +69,21 @@ export class AssetSubCategoriesComponent extends React.Component {
           <div id="page-heading-section">
             <Header as="h1" id="page-headings" floated="left" content="Asset Sub-Categories" />
             <Divider id="assets-divider" />
+            <div className="header-modal-button">
+              <ModalComponent
+                trigger={
+                  <Button
+                    className="add-asset"
+                    size="medium"
+                  >
+                    ADD SUB-CATEGORY
+                  </Button>
+                }
+                modalTitle="Add Sub-Category"
+              >
+                <AddSubCategoryContainer />
+              </ModalComponent>
+            </div>
           </div>
           <Table basic selectable>
             <Table.Header>

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -8,14 +8,8 @@ import {
 import { SemanticToastContainer } from 'react-semantic-toasts';
 import PropTypes from 'prop-types';
 import TableRowComponent from './TableRowComponent';
-import ModalComponent from './common/ModalComponent';
 import LoaderComponent from './LoaderComponent';
-import ModelNumberContainer from '../_components/ModelNumber/ModelNumberContainer';
-import AssetTypesContainer from '../_components/AssetTypes/AddAssetTypesContainer';
-import CategoryContainer from '../_components/Category/CategoryContainer';
-import AssetMakeContainer from '../_components/AssetMake/AssetMakeContainer';
 import { ToastMessage } from '../_utils/ToastMessage';
-import AddSubCategoryContainer from '../_components/SubCategory/AddSubCategoriesContainer';
 import rowOptions from '../_utils/pageRowOptions';
 import DropdownComponent from '../components/common/DropdownComponent';
 
@@ -50,33 +44,18 @@ const AssetsTableContent = (props) => {
             </Table.HeaderCell>
             <Table.HeaderCell>
               Model Number
-              <ModalComponent modalTitle="Add Asset Model Number">
-                <ModelNumberContainer />
-              </ModalComponent>
             </Table.HeaderCell>
             <Table.HeaderCell>
               Asset Make
-              <ModalComponent modalTitle="Add Asset Make">
-                <AssetMakeContainer />
-              </ModalComponent>
             </Table.HeaderCell>
             <Table.HeaderCell>
               Asset Type
-              <ModalComponent modalTitle="Add Asset Type">
-                <AssetTypesContainer />
-              </ModalComponent>
             </Table.HeaderCell>
             <Table.HeaderCell>
               Category
-              <ModalComponent modalTitle="Add Asset Category">
-                <CategoryContainer />
-              </ModalComponent>
             </Table.HeaderCell>
             <Table.HeaderCell>
               Sub-category
-              <ModalComponent modalTitle="Add Sub-Category">
-                <AddSubCategoryContainer />
-              </ModalComponent>
             </Table.HeaderCell>
           </Table.Row>
         </Table.Header>


### PR DESCRIPTION
## What does this PR do?
- Remove plus icons in assets list page
## Description of Task to be completed?
- remove plus icons in assets list
- place plus icons in respective list pages
## How should this be manually tested?
- Login to ART
- Go to the assets list page. The plus icons are no longer there.
- Go to the Categories, SubCategories, Asset Types, Asset Makes, and Model Number pages.
- There is a blue button on the right for each page to add a category, sub category etc
## What are the relevant pivotal tracker stories?
[#159880567](https://www.pivotaltracker.com/story/show/159880567)
## Any background context you want to add?
n/a
## Important notes
n/a
## Packages installed
n/a
## Deployment note
n/a
## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
<img width="1339" alt="screen shot 2018-08-28 at 13 15 19" src="https://user-images.githubusercontent.com/6042152/44717017-92529e00-aac4-11e8-83b6-92e2ac7526b8.png">
<img width="1300" alt="screen shot 2018-08-28 at 13 15 45" src="https://user-images.githubusercontent.com/6042152/44717018-92eb3480-aac4-11e8-8907-bb4313dff42c.png">
<img width="1298" alt="screen shot 2018-08-28 at 13 16 10" src="https://user-images.githubusercontent.com/6042152/44717019-92eb3480-aac4-11e8-9a08-025088a275e0.png">