### PR TITLE
#160253989 Prevent fetching asset details if they are in the store

### DIFF
--- a/src/__test__/AssetDescriptionComponent.test.js
+++ b/src/__test__/AssetDescriptionComponent.test.js
@@ -70,8 +70,6 @@ describe('Renders <AssetDescriptionComponent /> correctly', () => {
 
   it('renders the assign button and dropdown when no user is assigned', () => {
     wrapper.setState({ assignedUser: {}, assignAssetButtonState: true });
-    console.log(wrapper.debug());
-
     expect(wrapper.find('ButtonComponent').props().buttonName).toBe('Assign Asset');
     expect(wrapper.find('DropdownComponent').length).toBe(1);
   });

--- a/src/__test__/AssetDescriptionComponent.test.js
+++ b/src/__test__/AssetDescriptionComponent.test.js
@@ -3,26 +3,81 @@ import { mount } from 'enzyme';
 import expect from 'expect';
 
 import AssetDescriptionComponent from '../components/AssetDescriptionComponent';
+import assetMocks from '../_mock/newAllocation';
 
 describe('Renders <AssetDescriptionComponent /> correctly', () => {
   const props = {
-    assignedUser: {},
-    selectedUser: ''
+    assetDetail: assetMocks.assetDetails,
+    errorMessage: '',
+    loadAssetAssigneeUsers: jest.fn(),
+    allocateAsset: jest.fn(),
+    getAssetDetail: jest.fn(),
+    unassignAsset: jest.fn(),
+    hasError: false,
+    isLoading: {},
+    location: {
+      pathname: ''
+    }
   };
-  const wrapper = mount(<AssetDescriptionComponent {...props} />);
+  const wrapper = mount(<AssetDescriptionComponent.WrappedComponent {...props} />);
+  it('should mock the handleAssign function call', () => {
+    const handleAssignSpy = jest.spyOn(
+      wrapper.instance(), 'handleAssign'
+    );
+    wrapper.setProps({ buttonLoading: false });
+    wrapper.instance().handleAssign();
+    expect(handleAssignSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should mock the onSelectUserEmail function call', () => {
+    const onSelectUserEmailSpy = jest.spyOn(
+      wrapper.instance(), 'onSelectUserEmail'
+    );
+    const event = {};
+    const data = {};
+    wrapper.instance().onSelectUserEmail(event, data);
+    expect(onSelectUserEmailSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should mock the handleUnassign function call', () => {
+    const handleUnassignSpy = jest.spyOn(
+      wrapper.instance(), 'handleUnassign'
+    );
+    wrapper.instance().handleUnassign();
+    expect(handleUnassignSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should mock the handleConfirm function call', () => {
+    const handleConfirmSpy = jest.spyOn(
+      wrapper.instance(), 'handleConfirm'
+    );
+    wrapper.instance().handleConfirm();
+    expect(handleConfirmSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('should mock the handleUnassign function call if assignedUser is empty', () => {
+    const handleUnassignSpy = jest.spyOn(
+      wrapper.instance(), 'handleUnassign'
+    );
+    wrapper.setState({ assignedUser: {} });
+    wrapper.instance().handleConfirm();
+    expect(handleUnassignSpy.mock.calls.length).toEqual(1);
+  });
 
   it('renders the asset description component', () => {
     expect(wrapper.find('.asset-description').exists()).toEqual(true);
   });
 
   it('renders the assign button and dropdown when no user is assigned', () => {
-    wrapper.setProps({ assignedUser: {}, assignAssetButtonState: true });
+    wrapper.setState({ assignedUser: {}, assignAssetButtonState: true });
+    console.log(wrapper.debug());
+
     expect(wrapper.find('ButtonComponent').props().buttonName).toBe('Assign Asset');
     expect(wrapper.find('DropdownComponent').length).toBe(1);
   });
 
   it('renders the unassign button and email when a user is assigned', () => {
-    wrapper.setProps({ assignedUser: { email: 'email@TextTrackList.com' }, assignAssetButtonState: false });
+    wrapper.setState({ assignedUser: { email: 'email@TextTrackList.com' }, assignAssetButtonState: false });
     expect(wrapper.find('ButtonComponent').props().buttonName).toBe('Unassign Asset');
     expect(wrapper.find('#email').length).toBe(1);
   });

--- a/src/__test__/AssetDetailComponent.test.js
+++ b/src/__test__/AssetDetailComponent.test.js
@@ -28,48 +28,4 @@ describe('Renders <AssetDetailComponent /> correctly', () => {
   it('renders the AssetsDetailsContent component', () => {
     expect(wrapper.find('AssetDetailContent').length).toBe(1);
   });
-
-  it('should mock the onSelectUserEmail function call', () => {
-    const onSelectUserEmailSpy = jest.spyOn(
-      wrapper.instance(), 'onSelectUserEmail'
-    );
-    const event = {};
-    const data = {};
-    wrapper.instance().onSelectUserEmail(event, data);
-    expect(onSelectUserEmailSpy.mock.calls.length).toEqual(1);
-  });
-
-  it('should mock the handleAssign function call', () => {
-    const handleAssignSpy = jest.spyOn(
-      wrapper.instance(), 'handleAssign'
-    );
-    wrapper.setProps({ buttonLoading: false });
-    wrapper.instance().handleAssign();
-    expect(handleAssignSpy.mock.calls.length).toEqual(1);
-  });
-
-  it('should mock the handleUnassign function call', () => {
-    const handleUnassignSpy = jest.spyOn(
-      wrapper.instance(), 'handleUnassign'
-    );
-    wrapper.instance().handleUnassign();
-    expect(handleUnassignSpy.mock.calls.length).toEqual(1);
-  });
-
-  it('should mock the handleConfirm function call', () => {
-    const handleConfirmSpy = jest.spyOn(
-      wrapper.instance(), 'handleConfirm'
-    );
-    wrapper.instance().handleConfirm();
-    expect(handleConfirmSpy.mock.calls.length).toEqual(1);
-  });
-
-  it('should mock the handleUnassign function call if assignedUser is empty', () => {
-    const handleUnassignSpy = jest.spyOn(
-      wrapper.instance(), 'handleUnassign'
-    );
-    wrapper.setState({ assignedUser: {} });
-    wrapper.instance().handleConfirm();
-    expect(handleUnassignSpy.mock.calls.length).toEqual(1);
-  });
 });

--- a/src/_css/AssetDetailContent.scss
+++ b/src/_css/AssetDetailContent.scss
@@ -12,11 +12,12 @@
 
 .details-headings div,
 .details-description div {
-  margin: 1.2rem auto;
+  margin: 1.4rem auto;
 }
 
 .details-headings div {
   margin-left: 1rem;
+  font-size: 1.2rem;
 }
 
 .edit-asset-detail {

--- a/src/_css/AssetDetailContent.scss
+++ b/src/_css/AssetDetailContent.scss
@@ -15,9 +15,10 @@
   margin: 1.4rem auto;
 }
 
-.details-headings div {
+.details-headings div p {
   margin-left: 1rem;
   font-size: 1.2rem;
+  font-weight: bolder;
 }
 
 .edit-asset-detail {

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -1,7 +1,11 @@
 import React from 'react';
+import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isEmpty, values } from 'lodash';
 import { Container, Header, Grid } from 'semantic-ui-react';
+import { loadAssetAssigneeUsers } from '../_actions/users.actions';
+import { allocateAsset, unassignAsset } from '../_actions/asset.actions';
+
 import ModalComponent from './common/ModalComponent';
 import ButtonComponent from '../components/common/ButtonComponent';
 import ConfirmAction from './common/ConfirmAction';
@@ -25,7 +29,7 @@ handleAssign = () => {
     asset: id,
     current_owner: selectedUser
   };
-  this.props.allocateAsset(assetAllocated, this.state.serialNumber);
+  this.props.allocateAsset(assetAllocated, this.props.serialNumber);
 };
 
 handleUnassign = () => {
@@ -43,22 +47,24 @@ handleConfirm = () => {
   }
   return this.handleUnassign();
 };
+
 triggerProps = () => {
-  let triggerProps = {
-    buttonName: 'Assign Asset',
-    customCss: 'assign-asset',
-    disabledState: this.state.assignAssetButtonState,
+  if (isEmpty(values(this.state.assignedUser))) {
+    return {
+      buttonName: 'Assign Asset',
+      customCss: 'assign-asset',
+      disabledState: this.state.assignAssetButtonState,
+      color: 'primary'
+    };
+  }
+  return {
+    buttonName: 'Unassign Asset',
+    customCss: 'unassign-asset',
+    disabledState: false,
     color: 'primary'
   };
-  if (!isEmpty(values(this.state.assignedUser))) {
-    triggerProps = {
-      buttonName: 'Unassign Asset',
-      customCss: 'unassign-asset',
-      disabledState: false
-    };
-    return triggerProps;
-  } return triggerProps;
 }
+
 render() {
   const { onSelectUserEmail, assignedUser } = this.state;
   const { users, selectedUserId, toggleModal, buttonState, buttonLoading } = this.props;
@@ -121,4 +127,8 @@ AssetDescriptionComponent.defaultProps = {
   selectedUserId: 0
 };
 
-export default AssetDescriptionComponent;
+export default connect(null, {
+  loadAssetAssigneeUsers,
+  allocateAsset,
+  unassignAsset
+})(AssetDescriptionComponent);

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -19,91 +19,92 @@ class AssetDescriptionComponent extends React.Component {
    selectedUser: 0
  }
 
- onSelectUserEmail = (event, data) => {
-   this.setState({ selectedUser: data.value, assignAssetButtonState: false });
- };
-
-handleAssign = () => {
-  const { selectedUser } = this.state;
-  const { id } = this.props.assetDetail;
-  const assetAllocated = {
-    asset: id,
-    current_owner: selectedUser
+  onSelectUserEmail = (event, data) => {
+    this.setState({ selectedUser: data.value, assignAssetButtonState: false });
   };
-  this.props.allocateAsset(assetAllocated, this.props.serialNumber);
-};
 
-handleUnassign = () => {
-  const { id } = this.props.assetDetail;
-  const assetAssigned = {
-    asset: id,
-    current_status: 'Available'
+  handleAssign = () => {
+    const { selectedUser } = this.state;
+    const { id } = this.props.assetDetail;
+    const assetAllocated = {
+      asset: id,
+      current_owner: selectedUser
+    };
+    this.props.allocateAsset(assetAllocated, this.state.serialNumber);
   };
-  this.props.unassignAsset(assetAssigned, this.props.serialNumber);
-};
 
-handleConfirm = () => {
-  if (isEmpty(values(this.state.assignedUser))) {
-    return this.handleAssign();
-  }
-  return this.handleUnassign();
-};
+  handleUnassign = () => {
+    const { id } = this.props.assetDetail;
+    const assetAssigned = {
+      asset: id,
+      current_status: 'Available'
+    };
+    this.props.unassignAsset(assetAssigned, this.props.serialNumber);
+  };
 
-triggerProps = () => {
-  if (isEmpty(values(this.state.assignedUser))) {
+  handleConfirm = () => {
+    if (isEmpty(values(this.state.assignedUser))) {
+      return this.handleAssign();
+    }
+    return this.handleUnassign();
+  };
+
+  triggerProps = () => {
+    if (isEmpty(values(this.state.assignedUser))) {
+      return {
+        buttonName: 'Assign Asset',
+        customCss: 'assign-asset',
+        disabledState: this.state.assignAssetButtonState,
+        color: 'primary'
+      };
+    }
+
     return {
-      buttonName: 'Assign Asset',
-      customCss: 'assign-asset',
-      disabledState: this.state.assignAssetButtonState,
+      buttonName: 'Unassign Asset',
+      customCss: 'unassign-asset',
+      disabledState: false,
       color: 'primary'
     };
   }
-  return {
-    buttonName: 'Unassign Asset',
-    customCss: 'unassign-asset',
-    disabledState: false,
-    color: 'primary'
-  };
-}
 
-render() {
-  const { onSelectUserEmail, assignedUser } = this.state;
-  const { users, selectedUserId, toggleModal, buttonState, buttonLoading } = this.props;
-  const triggerProps = this.triggerProps();
-  return (
-    <Container>
-      <Grid columns={2} stackable className="asset-description">
-        <Grid.Column>
-          <Header as="h3" content="Asset Specs" />
-          <div className="asset-specs">
-            12-inch (diagonal) LED-backlit display with IPS technology
-            2304-by-1440 resolution at 226 pixels per inch with support for millions of colors
-            16:10 aspect ratio
-          </div>
-        </Grid.Column>
-        <Grid.Column>
-          <AssignedTo
-            onSelectUserEmail={onSelectUserEmail}
-            assignedUser={assignedUser}
-            users={users}
-            selectedUserId={selectedUserId}
-          />
-          <ModalComponent
-            trigger={<ButtonComponent {...triggerProps} />}
-            modalTitle="Confirm Action"
-          >
-            <ConfirmAction
-              toggleModal={toggleModal}
-              handleConfirm={this.handleConfirm}
-              buttonState={buttonState}
-              buttonLoading={buttonLoading}
+  render() {
+    const { onSelectUserEmail, assignedUser } = this.state;
+    const { users, selectedUserId, toggleModal, buttonState, buttonLoading } = this.props;
+    const triggerProps = this.triggerProps();
+    return (
+      <Container>
+        <Grid columns={2} stackable className="asset-description">
+          <Grid.Column>
+            <Header as="h3" content="Asset Specs" />
+            <div className="asset-specs">
+              12-inch (diagonal) LED-backlit display with IPS technology
+              2304-by-1440 resolution at 226 pixels per inch with support for millions of colors
+              16:10 aspect ratio
+            </div>
+          </Grid.Column>
+          <Grid.Column>
+            <AssignedTo
+              onSelectUserEmail={onSelectUserEmail}
+              assignedUser={assignedUser}
+              users={users}
+              selectedUserId={selectedUserId}
             />
-          </ModalComponent>
-        </Grid.Column>
-      </Grid>
-    </Container>
-  );
-}
+            <ModalComponent
+              trigger={<ButtonComponent {...triggerProps} />}
+              modalTitle="Confirm Action"
+            >
+              <ConfirmAction
+                toggleModal={toggleModal}
+                handleConfirm={this.handleConfirm}
+                buttonState={buttonState}
+                buttonLoading={buttonLoading}
+              />
+            </ModalComponent>
+          </Grid.Column>
+        </Grid>
+      </Container>
+    );
+  }
 }
 
 AssetDescriptionComponent.propTypes = {

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -8,23 +8,61 @@ import ConfirmAction from './common/ConfirmAction';
 import AssignedTo from './AssignAssetComponent';
 import '../_css/AssetDescriptionComponent.css';
 
-const AssetDescriptionComponent = (props) => {
+class AssetDescriptionComponent extends React.Component {
+ state = {
+   assignedUser: {},
+   assignAssetButtonState: true,
+   selectedUser: 0
+ }
+ onSelectUserEmail = (event, data) => {
+   this.setState({ selectedUser: data.value, assignAssetButtonState: false });
+ };
+
+handleAssign = () => {
+  const { selectedUser } = this.state;
+  const { id } = this.props.assetDetail;
+  const assetAllocated = {
+    asset: id,
+    current_owner: selectedUser
+  };
+  this.props.allocateAsset(assetAllocated, this.state.serialNumber);
+};
+
+handleUnassign = () => {
+  const { id } = this.props.assetDetail;
+  const assetAssigned = {
+    asset: id,
+    current_status: 'Available'
+  };
+  this.props.unassignAsset(assetAssigned, this.props.serialNumber);
+};
+
+handleConfirm = () => {
+  if (isEmpty(values(this.state.assignedUser))) {
+    return this.handleAssign();
+  }
+  return this.handleUnassign();
+};
+triggerProps = () => {
   let triggerProps = {
     buttonName: 'Assign Asset',
     customCss: 'assign-asset',
-    disabledState: props.assignAssetButtonState,
+    disabledState: this.state.assignAssetButtonState,
     color: 'primary'
   };
-
-  if (!isEmpty(values(props.assignedUser))) {
+  if (!isEmpty(values(this.state.assignedUser))) {
     triggerProps = {
-      ...triggerProps,
       buttonName: 'Unassign Asset',
       customCss: 'unassign-asset',
       disabledState: false
     };
-  }
-
+    return triggerProps;
+  } return triggerProps;
+}
+render() {
+  const { onSelectUserEmail, assignedUser } = this.state;
+  const { users, selectedUserId, toggleModal, buttonState, buttonLoading } = this.props;
+  const triggerProps = this.triggerProps();
   return (
     <Container>
       <Grid columns={2} stackable className="asset-description">
@@ -38,27 +76,28 @@ const AssetDescriptionComponent = (props) => {
         </Grid.Column>
         <Grid.Column>
           <AssignedTo
-            onSelectUserEmail={props.onSelectUserEmail}
-            assignedUser={props.assignedUser}
-            users={props.users}
-            selectedUserId={props.selectedUserId}
+            onSelectUserEmail={onSelectUserEmail}
+            assignedUser={assignedUser}
+            users={users}
+            selectedUserId={selectedUserId}
           />
           <ModalComponent
             trigger={<ButtonComponent {...triggerProps} />}
             modalTitle="Confirm Action"
           >
             <ConfirmAction
-              toggleModal={props.toggleModal}
-              handleConfirm={props.handleConfirm}
-              buttonState={props.buttonState}
-              buttonLoading={props.buttonLoading}
+              toggleModal={toggleModal}
+              handleConfirm={this.handleConfirm}
+              buttonState={buttonState}
+              buttonLoading={buttonLoading}
             />
           </ModalComponent>
         </Grid.Column>
       </Grid>
     </Container>
   );
-};
+}
+}
 
 AssetDescriptionComponent.propTypes = {
   onSelectUserEmail: PropTypes.func,
@@ -69,7 +108,12 @@ AssetDescriptionComponent.propTypes = {
   toggleModal: PropTypes.func,
   handleConfirm: PropTypes.func.isRequired,
   buttonState: PropTypes.bool.isRequired,
-  buttonLoading: PropTypes.bool.isRequired
+  buttonLoading: PropTypes.bool.isRequired,
+  unAssignedAsset: PropTypes.object,
+  assetDetail: PropTypes.object,
+  allocateAsset: PropTypes.func,
+  serialNumber: PropTypes.string,
+  unassignAsset: PropTypes.func
 };
 
 AssetDescriptionComponent.defaultProps = {

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -18,6 +18,7 @@ class AssetDescriptionComponent extends React.Component {
    assignAssetButtonState: true,
    selectedUser: 0
  }
+
  onSelectUserEmail = (event, data) => {
    this.setState({ selectedUser: data.value, assignAssetButtonState: false });
  };

--- a/src/components/AssetDetailComponent.jsx
+++ b/src/components/AssetDetailComponent.jsx
@@ -1,7 +1,7 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import { isEmpty, values } from 'lodash';
+import { isEmpty } from 'lodash';
 import { Container, Header } from 'semantic-ui-react';
 import { getAssetDetail, allocateAsset, unassignAsset } from '../_actions/asset.actions';
 import { loadAssetAssigneeUsers } from '../_actions/users.actions';
@@ -11,10 +11,7 @@ import LoaderComponent from './LoaderComponent';
 
 export class AssetDetailComponent extends Component {
   state = {
-    assignedUser: {},
-    selectedUser: 0,
     serialNumber: '',
-    assignAssetButtonState: true,
     hasError: this.props.hasError,
     errorMessage: this.props.errorMessage
   };
@@ -34,62 +31,29 @@ export class AssetDetailComponent extends Component {
     this.props.getAssetDetail(serialNumber);
   }
 
-  onSelectUserEmail = (event, data) => {
-    this.setState({ selectedUser: data.value, assignAssetButtonState: false });
-  };
-
-  handleAssign = () => {
-    const { selectedUser } = this.state;
-    const { id } = this.props.assetDetail;
-    const assetAllocated = {
-      asset: id,
-      current_owner: selectedUser
-    };
-    this.props.allocateAsset(assetAllocated, this.state.serialNumber);
-  };
-
-  handleUnassign = () => {
-    const { id } = this.props.assetDetail;
-    const assetAssigned = {
-      asset: id,
-      current_status: 'Available'
-    };
-    this.props.unassignAsset(assetAssigned, this.state.serialNumber);
-  };
-
-  handleConfirm = () => {
-    if (isEmpty(values(this.state.assignedUser))) {
-      return this.handleAssign();
-    }
-    return this.handleUnassign();
-  };
-
   render() {
+    let renderedComponent;
+    if (isEmpty(this.props.assetDetail)) {
+      renderedComponent = <LoaderComponent loadingText="Loading" />;
+    } else {
+      renderedComponent = (<AssetDetailContent
+        {...this.props}
+        assetDetail={this.props.assetDetail}
+        errorMessage={this.state.errorMessage}
+        hasError={this.state.hasError}
+        isLoading={this.props.isLoading}
+        show={this.show}
+        handleCancel={this.handleCancel}
+        buttonState={this.props.buttonLoading}
+        users={this.props.assetAsigneeUsers}
+        serialNumber={this.state.serialNumber}
+      />);
+    }
     return (
       <NavbarComponent>
         <Container>
           <Header as="h1" content="Asset Detail" className="asset-detail-header" />
-          { isEmpty(this.props.assetDetail) ?
-            <LoaderComponent loadingText="Loading" /> :
-            <AssetDetailContent
-              {...this.props}
-              assetDetail={this.props.assetDetail}
-              assignedUser={this.state.assignedUser}
-              errorMessage={this.state.errorMessage}
-              hasError={this.state.hasError}
-              isLoading={this.props.isLoading}
-              onSelectUserEmail={this.onSelectUserEmail}
-              handleAssign={this.handleAssign}
-              handleUnassign={this.handleUnassign}
-              selectedUserId={this.state.selectedUser}
-              show={this.show}
-              handleConfirm={this.handleConfirm}
-              handleCancel={this.handleCancel}
-              buttonState={this.props.buttonLoading}
-              assignAssetButtonState={this.state.assignAssetButtonState}
-              selectedUser={this.state.selectedUser}
-              users={this.props.assetAsigneeUsers}
-            />}
+          { renderedComponent }
         </Container>
       </NavbarComponent>
     );

--- a/src/components/AssetDetailComponent.jsx
+++ b/src/components/AssetDetailComponent.jsx
@@ -4,6 +4,7 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { Container, Header } from 'semantic-ui-react';
 import { getAssetDetail } from '../_actions/asset.actions';
+import { loadAssetAssigneeUsers } from '../_actions/users.actions';
 import AssetDetailContent from './AssetDetailContent';
 import NavbarComponent from './NavBarComponent';
 import LoaderComponent from './LoaderComponent';
@@ -16,12 +17,14 @@ export class AssetDetailComponent extends Component {
   };
 
   componentDidMount() {
-    const { assetDetail } = this.props;
+    const { assetDetail, assetAsigneeUsers } = this.props;
     if (isEmpty(assetDetail)) {
       this.getAssetId(this.props.location.pathname);
     }
+    if (isEmpty(assetAsigneeUsers)) {
+      this.props.loadAssetAssigneeUsers();
+    }
   }
-
 
   getAssetId(pathName) {
     const stringArray = pathName.split('/');
@@ -35,24 +38,24 @@ export class AssetDetailComponent extends Component {
     if (isEmpty(this.props.assetDetail)) {
       renderedComponent = <LoaderComponent loadingText="Loading" />;
     } else {
-      renderedComponent = (<AssetDetailContent
-        {...this.props}
-        assetDetail={this.props.assetDetail}
-        errorMessage={this.state.errorMessage}
-        hasError={this.state.hasError}
-        isLoading={this.props.isLoading}
-        show={this.show}
-        handleCancel={this.handleCancel}
-        buttonState={this.props.buttonLoading}
-        users={this.props.assetAsigneeUsers}
-        serialNumber={this.state.serialNumber}
-      />);
+      renderedComponent = (
+        <AssetDetailContent
+          assetDetail={this.props.assetDetail}
+          errorMessage={this.state.errorMessage}
+          hasError={this.state.hasError}
+          isLoading={this.props.isLoading}
+          show={this.show}
+          handleCancel={this.handleCancel}
+          buttonState={this.props.buttonLoading}
+          users={this.props.assetAsigneeUsers}
+          serialNumber={this.state.serialNumber}
+        />);
     }
     return (
       <NavbarComponent>
         <Container>
           <Header as="h1" content="Asset Detail" className="asset-detail-header" />
-          { renderedComponent }
+          {renderedComponent}
         </Container>
       </NavbarComponent>
     );
@@ -61,8 +64,6 @@ export class AssetDetailComponent extends Component {
 
 AssetDetailComponent.propTypes = {
   loadAssetAssigneeUsers: PropTypes.func,
-  allocateAsset: PropTypes.func,
-  unassignAsset: PropTypes.func,
   assetDetail: PropTypes.object,
   getAssetDetail: PropTypes.func,
   errorMessage: PropTypes.string,
@@ -70,9 +71,7 @@ AssetDetailComponent.propTypes = {
   isLoading: PropTypes.object,
   buttonLoading: PropTypes.bool,
   location: PropTypes.object,
-  assetAsigneeUsers: PropTypes.array,
-  newAllocation: PropTypes.object,
-  unAssignedAsset: PropTypes.object
+  assetAsigneeUsers: PropTypes.array
 };
 
 const mapStateToProps = ({ asset, usersList }, props) => {
@@ -102,4 +101,5 @@ const mapStateToProps = ({ asset, usersList }, props) => {
 };
 
 export default connect(mapStateToProps, {
-  getAssetDetail })(AssetDetailComponent);
+  getAssetDetail, loadAssetAssigneeUsers
+})(AssetDetailComponent);

--- a/src/components/AssetDetailComponent.jsx
+++ b/src/components/AssetDetailComponent.jsx
@@ -1,12 +1,13 @@
 import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import _, { isEmpty, values } from 'lodash';
+import { isEmpty, values } from 'lodash';
 import { Container, Header } from 'semantic-ui-react';
 import { getAssetDetail, allocateAsset, unassignAsset } from '../_actions/asset.actions';
 import { loadAssetAssigneeUsers } from '../_actions/users.actions';
 import AssetDetailContent from './AssetDetailContent';
 import NavbarComponent from './NavBarComponent';
+import LoaderComponent from './LoaderComponent';
 
 export class AssetDetailComponent extends Component {
   state = {
@@ -19,19 +20,12 @@ export class AssetDetailComponent extends Component {
   };
 
   componentDidMount() {
-    this.getAssetId(this.props.location.pathname);
-    if (_.isEmpty(this.props.assetAsigneeUsers)) {
-      this.props.loadAssetAssigneeUsers();
+    const { assetDetail } = this.props;
+    if (isEmpty(assetDetail)) {
+      this.getAssetId(this.props.location.pathname);
     }
   }
 
-  static getDerivedStateFromProps(nextProps) {
-    return {
-      assignedUser: nextProps.assetDetail.assigned_to,
-      hasError: nextProps.hasError,
-      errorMessage: nextProps.errorMessage
-    };
-  }
 
   getAssetId(pathName) {
     const stringArray = pathName.split('/');
@@ -75,25 +69,27 @@ export class AssetDetailComponent extends Component {
       <NavbarComponent>
         <Container>
           <Header as="h1" content="Asset Detail" className="asset-detail-header" />
-          <AssetDetailContent
-            {...this.props}
-            assetDetail={this.props.assetDetail}
-            assignedUser={this.state.assignedUser}
-            errorMessage={this.state.errorMessage}
-            hasError={this.state.hasError}
-            isLoading={this.props.isLoading}
-            onSelectUserEmail={this.onSelectUserEmail}
-            handleAssign={this.handleAssign}
-            handleUnassign={this.handleUnassign}
-            selectedUserId={this.state.selectedUser}
-            show={this.show}
-            handleConfirm={this.handleConfirm}
-            handleCancel={this.handleCancel}
-            buttonState={this.props.buttonLoading}
-            assignAssetButtonState={this.state.assignAssetButtonState}
-            selectedUser={this.state.selectedUser}
-            users={this.props.assetAsigneeUsers}
-          />
+          { isEmpty(this.props.assetDetail) ?
+            <LoaderComponent loadingText="Loading" /> :
+            <AssetDetailContent
+              {...this.props}
+              assetDetail={this.props.assetDetail}
+              assignedUser={this.state.assignedUser}
+              errorMessage={this.state.errorMessage}
+              hasError={this.state.hasError}
+              isLoading={this.props.isLoading}
+              onSelectUserEmail={this.onSelectUserEmail}
+              handleAssign={this.handleAssign}
+              handleUnassign={this.handleUnassign}
+              selectedUserId={this.state.selectedUser}
+              show={this.show}
+              handleConfirm={this.handleConfirm}
+              handleCancel={this.handleCancel}
+              buttonState={this.props.buttonLoading}
+              assignAssetButtonState={this.state.assignAssetButtonState}
+              selectedUser={this.state.selectedUser}
+              users={this.props.assetAsigneeUsers}
+            />}
         </Container>
       </NavbarComponent>
     );
@@ -116,7 +112,7 @@ AssetDetailComponent.propTypes = {
   unAssignedAsset: PropTypes.object
 };
 
-const mapStateToProps = ({ asset, usersList }) => {
+const mapStateToProps = ({ asset, usersList }, props) => {
   const {
     assetDetail,
     errorMessage,
@@ -132,7 +128,7 @@ const mapStateToProps = ({ asset, usersList }) => {
   };
   return {
     assetAsigneeUsers,
-    assetDetail,
+    assetDetail: isEmpty(props.location.state) ? assetDetail : props.location.state,
     newAllocation,
     unAssignedAsset,
     errorMessage,

--- a/src/components/AssetDetailComponent.jsx
+++ b/src/components/AssetDetailComponent.jsx
@@ -3,8 +3,7 @@ import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { Container, Header } from 'semantic-ui-react';
-import { getAssetDetail, allocateAsset, unassignAsset } from '../_actions/asset.actions';
-import { loadAssetAssigneeUsers } from '../_actions/users.actions';
+import { getAssetDetail } from '../_actions/asset.actions';
 import AssetDetailContent from './AssetDetailContent';
 import NavbarComponent from './NavBarComponent';
 import LoaderComponent from './LoaderComponent';
@@ -103,8 +102,4 @@ const mapStateToProps = ({ asset, usersList }, props) => {
 };
 
 export default connect(mapStateToProps, {
-  getAssetDetail,
-  loadAssetAssigneeUsers,
-  allocateAsset,
-  unassignAsset
-})(AssetDetailComponent);
+  getAssetDetail })(AssetDetailComponent);

--- a/src/components/TableRowComponent.jsx
+++ b/src/components/TableRowComponent.jsx
@@ -5,11 +5,11 @@ import { withRouter } from 'react-router-dom';
 
 export class TableRowComponent extends React.Component {
   handleView = () => {
-    const { viewDetailsRoute, history } = this.props;
+    const { viewDetailsRoute, history, data } = this.props;
     if (!viewDetailsRoute) {
       return null;
     }
-    return history.push(viewDetailsRoute, this.props.data);
+    return history.push(viewDetailsRoute, data);
   };
 
   render() {


### PR DESCRIPTION
## What does this PR do?
 - It prevents fetching data for asset details in the store.
## Description of Task to be completed?
 - Prevent fetching asset details for an asset whose details are already in the store
## How should this be manually tested?
 - Load asset list and click on an asset. It should load the asset details from the store.
- Copy the URL for the asset and open it on a guest window. It should fetch the asset details.
## What are the relevant pivotal tracker stories?
#[160253989](https://www.pivotaltracker.com/story/show/160253989)
## Any background context you want to add?
- none
## Important notes
- none
## Packages installed
- none
## Deployment note
- none