### PR TITLE
#160197002 Show relevant data on asset specs

### DIFF
--- a/src/__test__/AssetDescriptionComponent.test.js
+++ b/src/__test__/AssetDescriptionComponent.test.js
@@ -17,7 +17,10 @@ describe('Renders <AssetDescriptionComponent /> correctly', () => {
     isLoading: {},
     location: {
       pathname: ''
-    }
+    },
+    assignedUser: {},
+    selectedUser: '',
+    specs: {}
   };
   const wrapper = mount(<AssetDescriptionComponent.WrappedComponent {...props} />);
   it('should mock the handleAssign function call', () => {

--- a/src/_css/AssetDescriptionComponent.scss
+++ b/src/_css/AssetDescriptionComponent.scss
@@ -1,12 +1,16 @@
 @import "sharedStyling.scss";
 
 .asset-description {
-  padding: 4rem 2rem !important;
+  padding: 2rem 2rem !important;
   text-align: left;
 }
 
 .asset-specs {
   width: 25rem;
+
+  .asset-specs__label {
+    text-transform: capitalize;
+  }
 }
 
 .asset-user {

--- a/src/_css/AssetDetailContent.scss
+++ b/src/_css/AssetDetailContent.scss
@@ -30,10 +30,6 @@
   margin-top: 2rem;
 }
 
-.asset-tab-pane {
-  height: 22rem;
-}
-
 .asset-tab .allocation-history {
   overflow-y: auto;
 }

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -13,14 +13,41 @@ import AssignedTo from './AssignAssetComponent';
 import '../_css/AssetDescriptionComponent.css';
 
 class AssetDescriptionComponent extends React.Component {
- state = {
-   assignedUser: {},
-   assignAssetButtonState: true,
-   selectedUser: 0
- }
+  state = {
+    assignedUser: {},
+    assignAssetButtonState: true,
+    selectedUser: 0,
+    UNITS: {
+      processor_speed: 'GHz',
+      screen_size: 'inch',
+      storage: 'GB',
+      memory: 'GB'
+    }
+  }
 
   onSelectUserEmail = (event, data) => {
     this.setState({ selectedUser: data.value, assignAssetButtonState: false });
+  };
+
+  getSpecs = (specs) => {
+    const { UNITS } = this.state;
+    if (!specs) {
+      return 'This asset has no specifications';
+    }
+
+    delete specs.id;
+    return Object.entries(specs).map(([label, value]) => {
+      if (!value) {
+        return null;
+      }
+      const specUnit = UNITS[label] || ' ';
+      return (
+        <p>
+          <span className="asset-specs__label">{`${label.replace(/_/g, ' ')}: `}</span>
+          {`${value} ${specUnit}`}
+        </p>
+      );
+    });
   };
 
   handleAssign = () => {
@@ -69,7 +96,14 @@ class AssetDescriptionComponent extends React.Component {
 
   render() {
     const { onSelectUserEmail, assignedUser } = this.state;
-    const { users, selectedUserId, toggleModal, buttonState, buttonLoading } = this.props;
+    const {
+      users,
+      selectedUserId,
+      toggleModal,
+      buttonState,
+      buttonLoading,
+      assetDetail
+    } = this.props;
     const triggerProps = this.triggerProps();
     return (
       <Container>
@@ -77,9 +111,7 @@ class AssetDescriptionComponent extends React.Component {
           <Grid.Column>
             <Header as="h3" content="Asset Specs" />
             <div className="asset-specs">
-              12-inch (diagonal) LED-backlit display with IPS technology
-              2304-by-1440 resolution at 226 pixels per inch with support for millions of colors
-              16:10 aspect ratio
+              {this.getSpecs(assetDetail.specs)}
             </div>
           </Grid.Column>
           <Grid.Column>
@@ -121,7 +153,8 @@ AssetDescriptionComponent.propTypes = {
   assetDetail: PropTypes.object,
   allocateAsset: PropTypes.func,
   serialNumber: PropTypes.string,
-  unassignAsset: PropTypes.func
+  unassignAsset: PropTypes.func,
+  specs: PropTypes.object.isRequired
 };
 
 AssetDescriptionComponent.defaultProps = {


### PR DESCRIPTION
## What does this PR do?
Shows relevant data on asset specs rather than dummy data

## Description of Task to be completed?
- Refactor component to gain access to data from the store
- Refactor tests to accommodate new changes

## How should this be manually tested?
On the `asset list` page, click on a single `asset` to view its `details`. On the same page, `asset specs` can be viewed if they are available.

## What are the relevant pivotal tracker stories?
[#160197002](https://www.pivotaltracker.com/n/projects/2146417/stories/160197002)

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
- After implementing changes on PR
<img width="1252" alt="screen shot 2018-09-26 at 19 19 13" src="https://user-images.githubusercontent.com/31322228/46093891-39f4e600-c1c1-11e8-9e99-df0ac16ae4fb.png">

