### PR TITLE
[#160614085] Fix display of inaccurate data and refactor styling

### DIFF
--- a/src/_css/AssetDetailContent.scss
+++ b/src/_css/AssetDetailContent.scss
@@ -1,24 +1,34 @@
 @import "sharedStyling.scss";
 
+.ui.segment.asset-detail__segment,
+.ui.segment.asset-tab-pane {
+  border: 1px solid rgba(0, 0, 0, 0.2);
+}
+
+.ui.basic.table.asset-detail__table,
+.ui.basic.table.asset-detail__table tbody td,
+.ui.basic.table.asset-detail__table td:first-child,
+.ui.basic.table.asset-detail__table td:last-child {
+  border: 0;
+  border-radius: 0;
+  cursor: initial;
+  padding: 0;
+}
+
+.ui.basic.table.asset-detail__table tbody td.details-headings {
+  font-size: 1.2rem;
+  font-weight: bolder;
+  width: 50%;
+}
+
 .asset-details {
-  padding: 2rem 0;
+  padding: 2rem;
   text-align: left;
 }
 
 .asset-detail-header {
   text-align: left;
   margin-bottom: 1rem !important;
-}
-
-.details-headings div,
-.details-description div {
-  margin: 1.4rem auto;
-}
-
-.details-headings div p {
-  margin-left: 1rem;
-  font-size: 1.2rem;
-  font-weight: bolder;
 }
 
 .edit-asset-detail {

--- a/src/components/AssetDetailComponent.jsx
+++ b/src/components/AssetDetailComponent.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
-import { Container, Header } from 'semantic-ui-react';
+import { Container, Divider, Header } from 'semantic-ui-react';
 import { getAssetDetail } from '../_actions/asset.actions';
 import { loadAssetAssigneeUsers } from '../_actions/users.actions';
 import AssetDetailContent from './AssetDetailContent';
@@ -54,7 +54,10 @@ export class AssetDetailComponent extends Component {
     return (
       <NavbarComponent>
         <Container>
-          <Header as="h1" content="Asset Detail" className="asset-detail-header" />
+          <div id="page-heading-section">
+            <Header as="h1" id="page-headings" floated="left" content="Asset Detail" />
+            <Divider id="assets-divider" />
+          </div>
           {renderedComponent}
         </Container>
       </NavbarComponent>

--- a/src/components/AssetDetailContent.jsx
+++ b/src/components/AssetDetailContent.jsx
@@ -1,13 +1,14 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Grid, Segment, Icon, Tab } from 'semantic-ui-react';
+import { Grid, Segment, Icon, Tab, Table } from 'semantic-ui-react';
 import { SemanticToastContainer } from 'react-semantic-toasts';
-import '../_css/AssetDetailContent.css';
 import AssetAllocationHistory from './AssetAllocationHistory';
 import AssetDescriptionComponent from './AssetDescriptionComponent';
 import AssetNotes from './AssetNoteComponent';
 import { ToastMessage } from '../_utils/ToastMessage';
 import LoaderComponent from './LoaderComponent';
+
+import '../_css/AssetDetailContent.css';
 
 const AssetDetailContent = (props) => {
   if (Object.values(props.isLoading).find(loading => loading)) {
@@ -54,47 +55,75 @@ const AssetDetailContent = (props) => {
 
   return (
     <div>
-      <Segment raised>
+      <Segment raised className="asset-detail__segment">
         <div className="asset-details">
           <div className="edit-asset-detail">
             <Icon size="large" link name="pencil" />
           </div>
           <Grid columns={2} stackable divided>
             <Grid.Column>
-              <Grid columns={2}>
-                <Grid.Column className="details-headings">
-                  <div><p>Category</p></div>
-                  <div><p>Sub-category</p></div>
-                  <div><p>Type</p></div>
-                  <div><p>Make</p></div>
-                </Grid.Column>
-                <Grid.Column className="details-description">
-                  <div><p>Electronics</p></div>
-                  <div><p>Computer</p></div>
-                  <div><p> {assetDetail.asset_type}</p></div>
-                  <div><p>Microsoft</p></div>
+              <Grid columns={1}>
+                <Grid.Column>
+                  <Table basic="very" className="asset-detail__table">
+                    <Table.Body>
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Category</Table.Cell>
+                        <Table.Cell>{assetDetail.asset_category}</Table.Cell>
+                      </Table.Row>
+
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Sub-category</Table.Cell>
+                        <Table.Cell>{assetDetail.asset_sub_category}</Table.Cell>
+                      </Table.Row>
+
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Type</Table.Cell>
+                        <Table.Cell>{assetDetail.asset_type}</Table.Cell>
+                      </Table.Row>
+
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Make</Table.Cell>
+                        <Table.Cell>{assetDetail.make_label}</Table.Cell>
+                      </Table.Row>
+                    </Table.Body>
+                  </Table>
                 </Grid.Column>
               </Grid>
             </Grid.Column>
+
             <Grid.Column>
-              <Grid columns={2}>
-                <Grid.Column className="details-headings">
-                  <div><p>Asset Code</p></div>
-                  <div><p>Serial Number</p></div>
-                  <div><p>Model Number</p></div>
-                  <div><p>Asset Status</p></div>
-                </Grid.Column>
-                <Grid.Column className="details-description">
-                  <div><p>{assetDetail.asset_code || '-'}</p></div>
-                  <div><p>{assetDetail.serial_number || '-'}</p></div>
-                  <div><p>{assetDetail.model_number || '-'}</p></div>
-                  <div><p>{assetDetail.current_status || '-'}</p></div>
+              <Grid columns={1}>
+                <Grid.Column>
+                  <Table basic="very" className="asset-detail__table">
+                    <Table.Body>
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Asset Code</Table.Cell>
+                        <Table.Cell>{assetDetail.asset_code || '-'}</Table.Cell>
+                      </Table.Row>
+
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Serial Number</Table.Cell>
+                        <Table.Cell>{assetDetail.serial_number || '-'}</Table.Cell>
+                      </Table.Row>
+
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Model Number</Table.Cell>
+                        <Table.Cell>{assetDetail.model_number || '-'}</Table.Cell>
+                      </Table.Row>
+
+                      <Table.Row>
+                        <Table.Cell className="details-headings">Asset Status</Table.Cell>
+                        <Table.Cell>{assetDetail.current_status || '-'}</Table.Cell>
+                      </Table.Row>
+                    </Table.Body>
+                  </Table>
                 </Grid.Column>
               </Grid>
             </Grid.Column>
           </Grid>
         </div>
       </Segment>
+
       <Tab
         className="asset-tab"
         menu={{ secondary: true, pointing: true }}


### PR DESCRIPTION
## What does this PR do?

Fix data displayed in the asset detail page

## Description of Task to be completed?

```gherkin
### Steps to reproduce
1. Go to asset list page
2. Click on one of the assets (note the asset make, category, subcategory)
3. When the asset details load note the details on the page.
4. Go back to asset details page
5. Repeat steps 1-3 for a different asset

### Expected
- The details on the asset list page should match the details  of the asset loaded.

### Actual
- The asset loads, and makes load the same data for all the assets.
```

## How should this be manually tested?

* Log in
* Navigate to the assets page
* Click on one of the assets to view details
* Go back to assets page
* Click on another asset to see if the details displayed are correct

## What are the relevant pivotal tracker stories?

[160614085](https://www.pivotaltracker.com/story/show/160614085)

## Any background context you want to add?

N/A

## Important notes

N/A

## Packages installed

N/A

## Deployment note

N/A

## Related PRs branch | PR (branch_name) | (pr_link)

N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots

<img width="1680" alt="asset1" src="https://user-images.githubusercontent.com/31339738/46792331-cff54880-cd4b-11e8-9e5d-58ded88be6c6.png">

<img width="1680" alt="asset2" src="https://user-images.githubusercontent.com/31339738/46792340-d388cf80-cd4b-11e8-9aae-b6c27c39aacb.png">

