### PR TITLE
[#161053181] Fix inaccurate number of assigned assets displayed on the user table

### DIFF
--- a/src/components/User/UserComponent.jsx
+++ b/src/components/User/UserComponent.jsx
@@ -55,12 +55,17 @@ const UserComponent = (props) => {
           {
             props.activePageUsers.map((user) => {
               const viewUserUrl = `users/${user.id}/view`;
-              user.assets_assigned = 1;
+
+              const updatedUser = {
+                ...user,
+                assets_assigned: user.allocated_asset_count
+              };
+
               return (
                 <TableRow
                   viewDetailsRoute={viewUserUrl}
                   key={user.id}
-                  data={user}
+                  data={updatedUser}
                   headings={[
                     'full_name',
                     'email',


### PR DESCRIPTION
## What does this PR do?

Fixes the inaccurate number of assigned assets being displayed on the user table

## Description of Task to be completed?

```gherkin
Scenario: An admin should see the accurate number of assigned assets.
Given an admin with access
When I visit the user page
Then I should see accurate data on the assigned assets column
```

## How should this be manually tested?

* Log in
* Navigate to the users page
* View the number of assigned assets in the assigned asset column to confirm if the numbers shown are accurate

## What are the relevant pivotal tracker stories?

[161053181](https://www.pivotaltracker.com/story/show/161053181)

## Any background context you want to add?

N/A

## Important notes

N/A

## Packages installed

N/A

## Deployment note

N/A

## Related PRs branch | PR (branch_name) | (pr_link)

N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots

<img width="1680" alt="screenshot 2018-10-31 at 12 05 05" src="https://user-images.githubusercontent.com/31339738/47777184-3e9f4380-dd05-11e8-9542-d255ea0c8e80.png">
