### PR TITLE
[#161281468] Only show full page loading  spinner when loading assets

### DIFF
--- a/src/__test__/AssetsComponent.test.js
+++ b/src/__test__/AssetsComponent.test.js
@@ -2,17 +2,18 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import expect from 'expect';
 
-import { AssetsComponent } from '../components/AssetsComponent';
+import AssetsComponent from '../components/AssetsComponent';
 
 import assets from '../_mock/assets';
 import assetModels from '../_mock/assetModels';
 import assetTypes from '../_mock/assetTypes';
+import filters from '../_mock/filters';
 
 describe('Renders <AssetsComponent /> correctly', () => {
   const props = {
     getAssetsAction: jest.fn(),
     handlePaginationChange: jest.fn(),
-    createFilterData: jest.fn(),
+    filterData: filters,
     handleRowChange: jest.fn(),
     setActivePage: jest.fn(),
     loadAllAssetModels: jest.fn(),
@@ -47,14 +48,6 @@ describe('Renders <AssetsComponent /> correctly', () => {
     expect(shouldComponentUpdateSpy.mock.calls.length).toBe(1);
   });
 
-  it('calls the emptyAssetsCheck function to check if the assetsList is empty', () => {
-    const emptyAssetsCheckSpy = jest.spyOn(
-      wrapper.instance(), 'emptyAssetsCheck'
-    );
-    wrapper.instance().emptyAssetsCheck();
-    expect(emptyAssetsCheckSpy.mock.calls.length).toEqual(1);
-  });
-
   it('calls the handlePaginationChange function when the next button is clicked', () => {
     const handlePaginationChangeSpy = jest.spyOn(
       wrapper.instance(), 'handlePaginationChange'
@@ -71,14 +64,6 @@ describe('Renders <AssetsComponent /> correctly', () => {
     );
     wrapper.instance().handlePageTotal();
     expect(handlePageTotalSpy.mock.calls.length).toEqual(1);
-  });
-
-  it('calls the createFilterData function to loop through the asset types and model numbers', () => {
-    const createFilterDataSpy = jest.spyOn(
-      wrapper.instance(), 'createFilterData'
-    );
-    wrapper.instance().createFilterData();
-    expect(createFilterDataSpy.mock.calls.length).toEqual(1);
   });
 
   it('calls handleRowChange when a  number of rows are selected', () => {

--- a/src/__test__/AssetsTableContent.test.js
+++ b/src/__test__/AssetsTableContent.test.js
@@ -8,26 +8,19 @@ import assets from '../_mock/assets';
 
 describe('Renders <AssetsTableContent /> correctly', () => {
   const props = {
-    getAssetsAction: jest.fn(),
-    activePage: 1,
-    handlePaginationChange: jest.fn(),
-    activePageAssets: assets,
-    assetsCount: 10,
-    emptyAssetsCheck: jest.fn(),
     errorMessage: '',
-    handlePageTotal: jest.fn((() => (1))),
     hasError: false,
-    isLoading: false
+    isLoading: false,
+    hasAssets: true,
+    message: '',
+    assets
   };
-  const wrapper = shallow(<AssetsTableContent
-    {...props}
-  />);
-
-  it('renders Pagination component', () => {
-    expect(wrapper.find('Pagination').length).toBe(1);
-  });
+  const wrapper = shallow(<AssetsTableContent {...props} />);
 
   it('renders Table component', () => {
+    wrapper.setProps({
+      assets
+    });
     expect(wrapper.find('Table').length).toBe(1);
   });
 
@@ -43,9 +36,10 @@ describe('Renders <AssetsTableContent /> correctly', () => {
 
   it('renders message if there are no assets returned', () => {
     wrapper.setProps({
-      emptyAssetsCheck: () => (true),
+      assets: [],
+      hasAssets: false,
       hasError: false
     });
-    expect(wrapper.find('#empty-assets').prop('content')).toEqual('No Assets Found');
+    expect(wrapper.find('ItemsNotFoundComponent').length).toBe(1);
   });
 });

--- a/src/__test__/PaginationComponent.test.js
+++ b/src/__test__/PaginationComponent.test.js
@@ -1,0 +1,21 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import expect from 'expect';
+
+import PaginationComponent from '../components/common/PaginationComponent';
+
+describe('renders <PaginationComponent /> correctly', () => {
+  const wrapper = shallow(<PaginationComponent />);
+
+  it('renders a Segment', () => {
+    expect(wrapper.find('Segment').length).toBe(2);
+  });
+
+  it('renders a Pagination Component', () => {
+    expect(wrapper.find('Pagination').length).toBe(1);
+  });
+
+  it('renders a Dropdown Component', () => {
+    expect(wrapper.find('DropdownComponent').length).toBe(1);
+  });
+});

--- a/src/__test__/_components/AssetsContainer.test.js
+++ b/src/__test__/_components/AssetsContainer.test.js
@@ -1,0 +1,62 @@
+import expect from 'expect';
+import { mapStateToProps, createFilterData } from '../../_components/Assets/AssetsContainer';
+import models from '../../_mock/assetModels';
+import types from '../../_mock/assetTypes';
+
+describe('Renders <Assets />  tests', () => {
+  it('calls mapStateToProps', () => {
+    const state = {
+      assets: {
+        assetsList: [],
+        isLoading: false,
+        assetsCount: 0,
+        errorMessage: '',
+        hasError: false,
+        activePage: 1
+      },
+      assetModelsList: {
+        assetModel: []
+      },
+      assetTypesList: {
+        assetTypes: []
+      },
+      selected: []
+    };
+
+    const expected = {
+      isLoading: false,
+      assetsList: [],
+      assetsCount: 0,
+      errorMessage: '',
+      hasError: false,
+      activePage: 1,
+      selected: [],
+      filterData: []
+    };
+
+    expect(mapStateToProps(state)).toEqual(expected);
+  });
+
+  it('calls createFilterData', () => {
+    const expected = [
+      {
+        title: 'Asset Types',
+        content: [
+          { id: 0, option: 'Timor-Leste' },
+          { id: 1, option: 'monitoring' },
+          { id: 2, option: 'circuit' }
+        ]
+      },
+      {
+        title: 'Model Numbers',
+        content: [
+          { id: 1, option: 'MC-LifeChat 5' },
+          { id: 2, option: 'Microsoft Lifechat LX-6000' },
+          { id: 3, option: 'Spectre x360' }
+        ]
+      }
+    ];
+
+    expect(createFilterData(types, models)).toEqual(expected);
+  });
+});

--- a/src/__test__/components/FilterButton.test.js
+++ b/src/__test__/components/FilterButton.test.js
@@ -2,13 +2,13 @@ import React from 'react';
 import { shallow } from 'enzyme';
 import expect from 'expect';
 import Filter from '../../components/common/FilterButton';
-import filters from '../../_mock/filters';
+import { selectedFilters } from '../../_mock/filters';
 
 describe('Renders <FilterButton /> tests', () => {
   const props = {
     activePage: 1,
     limit: 10,
-    selected: filters,
+    selected: selectedFilters,
     handleFilter: jest.fn(),
     filterAction: jest.fn()
   };

--- a/src/__test__/components/FilterComponent.test.js
+++ b/src/__test__/components/FilterComponent.test.js
@@ -5,7 +5,7 @@ import expect from 'expect';
 import FilterComponent from '../../components/common/FilterComponent';
 
 import assetFilter from '../../_mock/assetsFilter';
-import filters from '../../_mock/filters';
+import { selectedFilters } from '../../_mock/filters';
 
 describe('Renders <FilterComponent /> correctly', () => {
   const props = {
@@ -13,7 +13,7 @@ describe('Renders <FilterComponent /> correctly', () => {
     handleCheckboxChange: jest.fn(),
     handleClose: jest.fn(),
     option: assetFilter[0],
-    selected: filters,
+    selected: selectedFilters,
     filterSelection: jest.fn(),
     index: 0
   };

--- a/src/_components/Assets/AssetsContainer.jsx
+++ b/src/_components/Assets/AssetsContainer.jsx
@@ -1,0 +1,66 @@
+import { connect } from 'react-redux';
+import isEmpty from 'lodash/isEmpty';
+
+import { getAssetsAction, setActivePage } from '../../_actions/assets.action';
+import { loadAllAssetModels } from '../../_actions/assetModels.action';
+import { loadDropdownAssetTypes } from '../../_actions/assetTypes.actions';
+import filterSelection from '../../_actions/checkedFilters.actions';
+
+import Assets from '../../components/AssetsComponent';
+
+const formatOption = (data, optionKey) => ({
+  id: data.id,
+  option: data[optionKey]
+});
+
+export const createFilterData = (assetTypes, assetModels) => {
+  if (isEmpty(assetTypes) && isEmpty(assetModels)) {
+    return [];
+  }
+
+  const formattedAssetTypes = assetTypes.map(assetType => formatOption(assetType, 'asset_type'));
+  const formattedAssetModels = assetModels.map(assetModel => formatOption(assetModel, 'model_number'));
+
+  return [
+    {
+      title: 'Asset Types',
+      content: formattedAssetTypes
+    },
+    {
+      title: 'Model Numbers',
+      content: formattedAssetModels
+    }
+  ];
+};
+
+export const mapStateToProps = ({ assets, assetTypesList, assetModelsList, selected }) => {
+  const {
+    assetsList,
+    assetsCount,
+    errorMessage,
+    hasError,
+    isLoading,
+    activePage
+  } = assets;
+  const { assetModels } = assetModelsList;
+  const { assetTypes } = assetTypesList;
+
+  return {
+    assetsList,
+    assetsCount,
+    errorMessage,
+    hasError,
+    isLoading,
+    filterData: createFilterData(assetTypes, assetModels),
+    activePage,
+    selected
+  };
+};
+
+export default connect(mapStateToProps, {
+  getAssetsAction,
+  loadAllAssetModels,
+  loadDropdownAssetTypes,
+  setActivePage,
+  filterSelection
+})(Assets);

--- a/src/_components/RoutesComponent.jsx
+++ b/src/_components/RoutesComponent.jsx
@@ -2,7 +2,7 @@ import React, { Component } from 'react';
 import { Route, Switch } from 'react-router-dom';
 import Authenticate from './AuthenticateComponent';
 import AssetTypes from '../components/AssetTypesComponent';
-import Assets from '../components/AssetsComponent';
+import Assets from '../_components/Assets/AssetsContainer';
 import AssetModels from '../components/AssetModels/AssetModelsComponent';
 import LoginComponent from '../components/LoginComponent';
 import Dashboard from '../_components/Dashboard/DashboardContainer';

--- a/src/_css/AssetsComponent.scss
+++ b/src/_css/AssetsComponent.scss
@@ -35,7 +35,7 @@
   border-color: $andela-blue;
 }
 
-.filter-button {
+.ui.button.filter-button {
   border: $andela-blue solid 1px;
   padding: 13px;
   font-size: small;
@@ -47,7 +47,7 @@
   right: 8rem;
 }
 
-.clicked {
+.ui.button.clicked {
   background-color: $andela-white;
   color: $andela-blue;
 }

--- a/src/_css/LoaderComponent.scss
+++ b/src/_css/LoaderComponent.scss
@@ -2,10 +2,12 @@
 
 .ui.centered.three.column.grid > .column.loader-column {
   width: 64px;
+  padding-top: 250px;
 }
 
 .ui.inverted.dimmer.overlay {
   background-color: rgba(255, 255, 255, .95);
+  position: static !important;
 }
 
 .la-square-jelly-box {
@@ -17,4 +19,9 @@
   color: $andela-black;
   margin-top: 15px;
   text-align: center;
+}
+
+.loader-segment {
+  border: 0 !important;
+  box-shadow: none !important;
 }

--- a/src/_css/PaginationComponent.scss
+++ b/src/_css/PaginationComponent.scss
@@ -1,0 +1,11 @@
+@import "sharedStyling.scss";
+
+.asset-loading-pagination {
+  position: absolute;
+  top: 20vh;
+  left: 50vh;
+}
+
+.asset-loaded-pagination {
+  left: 45vh;
+}

--- a/src/_mock/filters.js
+++ b/src/_mock/filters.js
@@ -1,4 +1,9 @@
-const filters = {
+const filters = [
+  { asset_types: ['Headsets'] },
+  { model_numbers: ['HP 27ES'] }
+];
+
+export const selectedFilters = {
   asset_types: ['Headsets'],
   model_numbers: ['HP 27ES']
 };

--- a/src/components/AssetsComponent.jsx
+++ b/src/components/AssetsComponent.jsx
@@ -1,26 +1,20 @@
 import React, { Component } from 'react';
-import { connect } from 'react-redux';
 import { Header, Divider } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import NavBarComponent from '../_components/NavBarContainer';
 import AssetsTableContent from './AssetsTableContent';
-import '../_css/AssetsComponent.css';
-import { getAssetsAction, setActivePage } from '../_actions/assets.action';
-import { loadAllAssetModels } from '../_actions/assetModels.action';
-import { loadDropdownAssetTypes } from '../_actions/assetTypes.actions';
-import filterSelection from '../_actions/checkedFilters.actions';
 import FilterButton from './common/FilterButton';
 import FilterComponent from './common/FilterComponent';
+import PaginationComponent from './common/PaginationComponent';
+import '../_css/AssetsComponent.css';
 
-export class AssetsComponent extends Component {
+export default class AssetsComponent extends Component {
   state = {
     limit: 10
   };
 
   componentDidMount() {
-    this.props.loadAllAssetModels();
-    this.props.loadDropdownAssetTypes();
     const assetsEmpty = isEmpty(this.props.assetsList);
 
     // TODO: fix the logic so that assets are fetched when you create an asset before fetching
@@ -29,6 +23,9 @@ export class AssetsComponent extends Component {
     if (assetsEmpty || (!assetsEmpty && this.props.assetsList.length === 1)) {
       this.props.getAssetsAction(this.props.activePage, this.state.limit);
     }
+
+    this.props.loadAllAssetModels();
+    this.props.loadDropdownAssetTypes();
   }
 
   shouldComponentUpdate(nextProps) {
@@ -51,46 +48,9 @@ export class AssetsComponent extends Component {
 
   handlePageTotal = () => Math.ceil(this.props.assetsCount / this.state.limit);
 
-  emptyAssetsCheck = () => (isEmpty(this.props.assetsList));
-
-  createFilterData = () => {
-    const { assetModels, assetTypes } = this.props;
-
-    const allFilters = [];
-    const assetFilters = {
-      title: 'Asset Types',
-      content: []
-    };
-    const modelNumberFilters = {
-      title: 'Model Numbers',
-      content: []
-    };
-
-    if (!isEmpty(assetTypes) && !isEmpty(assetModels)) {
-      assetTypes.map(assetType => (
-        assetFilters.content.push({
-          id: assetType.id,
-          option: assetType.asset_type
-        })
-      ));
-
-      assetModels.map(assetModel => (
-        modelNumberFilters.content.push({
-          id: assetModel.id,
-          option: assetModel.model_number
-        })
-      ));
-
-      allFilters.push(assetFilters);
-      allFilters.push(modelNumberFilters);
-    }
-
-    return allFilters;
-  };
-
   render() {
-    const filters = this.createFilterData();
-
+    const totalPages = this.handlePageTotal();
+    const showPaginator = totalPages > 0;
     return (
       <NavBarComponent title="Assets">
         <div className="assets-list">
@@ -102,18 +62,19 @@ export class AssetsComponent extends Component {
               limit={this.state.limit}
               selected={this.props.selected}
               filterAction={this.props.getAssetsAction}
+              disabled={this.props.isLoading}
             >
               <React.Fragment>
                 <FilterComponent
                   index={0}
-                  option={filters[0]}
+                  option={this.props.filterData[0]}
                   selected={this.props.selected}
                   filterSelection={this.props.filterSelection}
                 />
 
                 <FilterComponent
                   index={1}
-                  option={filters[1]}
+                  option={this.props.filterData[1]}
                   selected={this.props.selected}
                   filterSelection={this.props.filterSelection}
                 />
@@ -121,18 +82,21 @@ export class AssetsComponent extends Component {
             </FilterButton>
           </div>
           <AssetsTableContent
-            {...this.props}
-            activePage={this.props.activePage}
-            activePageAssets={this.props.assetsList}
-            emptyAssetsCheck={this.emptyAssetsCheck}
+            assets={this.props.assetsList}
             errorMessage={this.props.errorMessage}
-            handlePageTotal={this.handlePageTotal}
-            handleRowChange={this.handleRowChange}
-            handlePaginationChange={this.handlePaginationChange}
             hasError={this.props.hasError}
             isLoading={this.props.isLoading}
-            limit={this.state.limit}
           />
+          {showPaginator && (
+            <PaginationComponent
+              activePage={this.props.activePage}
+              handleRowChange={this.handleRowChange}
+              handlePaginationChange={this.handlePaginationChange}
+              limit={this.state.limit}
+              totalPages={totalPages}
+              isLoading={this.props.isLoading}
+            />
+          )}
         </div>
       </NavBarComponent>
     );
@@ -148,13 +112,11 @@ AssetsComponent.propTypes = {
   loadAllAssetModels: PropTypes.func.isRequired,
   loadDropdownAssetTypes: PropTypes.func.isRequired,
   hasError: PropTypes.bool.isRequired,
-  history: PropTypes.object,
   isLoading: PropTypes.bool,
-  assetModels: PropTypes.arrayOf(PropTypes.object),
-  assetTypes: PropTypes.arrayOf(PropTypes.object),
   activePage: PropTypes.number,
   selected: PropTypes.object.isRequired,
-  filterSelection: PropTypes.func.isRequired
+  filterSelection: PropTypes.func.isRequired,
+  filterData: PropTypes.arrayOf(PropTypes.object)
 };
 
 AssetsComponent.defaultProps = {
@@ -163,36 +125,3 @@ AssetsComponent.defaultProps = {
   activePage: 1,
   isLoading: false
 };
-
-const mapStateToProps = ({ assets, assetTypesList, assetModelsList, selected }) => {
-  const {
-    assetsList,
-    assetsCount,
-    errorMessage,
-    hasError,
-    isLoading,
-    activePage
-  } = assets;
-  const { assetModels } = assetModelsList;
-  const { assetTypes } = assetTypesList;
-
-  return {
-    assetsList,
-    assetsCount,
-    errorMessage,
-    hasError,
-    isLoading,
-    assetModels,
-    assetTypes,
-    activePage,
-    selected
-  };
-};
-
-export default connect(mapStateToProps, {
-  getAssetsAction,
-  loadAllAssetModels,
-  loadDropdownAssetTypes,
-  setActivePage,
-  filterSelection
-})(AssetsComponent);

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -1,23 +1,22 @@
 import React from 'react';
-import {
-  Header,
-  Table,
-  Pagination,
-  Segment
-} from 'semantic-ui-react';
+import { Table } from 'semantic-ui-react';
 import { SemanticToastContainer } from 'react-semantic-toasts';
+import isEmpty from 'lodash/isEmpty';
 import PropTypes from 'prop-types';
 import TableRowDetail from './TableRowComponent';
 import LoaderComponent from './LoaderComponent';
 import { ToastMessage } from '../_utils/ToastMessage';
-import rowOptions from '../_utils/pageRowOptions';
-import DropdownComponent from '../components/common/DropdownComponent';
+import NotFound from './common/ItemsNotFoundComponent';
 
 const AssetsTableContent = (props) => {
+  const hasAssets = !isEmpty(props.assets);
+
   if (props.isLoading) {
     return <LoaderComponent />;
   }
 
+  // TODO: move this to appropriate component as it should not be here.
+  // And do we really need "SemanticToastContainer"? (food for thought)
   if (props.hasError && props.errorMessage) {
     setTimeout(() => {
       ToastMessage.error({ message: props.errorMessage });
@@ -25,9 +24,11 @@ const AssetsTableContent = (props) => {
     return <SemanticToastContainer />;
   }
 
-  if (props.emptyAssetsCheck()) {
+  if (!hasAssets) {
     return (
-      <Header as="h3" id="empty-assets" content="No Assets Found" />
+      <NotFound
+        message="Please try again later to see if there will be assets to show you."
+      />
     );
   }
 
@@ -62,7 +63,7 @@ const AssetsTableContent = (props) => {
 
         <Table.Body>
           {
-            props.activePageAssets.map((asset) => {
+            props.assets.map((asset) => {
               const assetViewUrl = `assets/${asset.uuid}/view`;
 
               const updatedAsset = {
@@ -91,54 +92,22 @@ const AssetsTableContent = (props) => {
             })
           }
         </Table.Body>
-
-        <Table.Footer>
-          <Table.Row>
-            {!props.emptyAssetsCheck() ? (
-              <Table.HeaderCell colSpan="8" id="pagination-header">
-                <Segment.Group horizontal id="art-pagination-section">
-                  <Segment>
-                    <Pagination
-                      id="art-pagination-component"
-                      totalPages={props.handlePageTotal()}
-                      onPageChange={props.handlePaginationChange}
-                      activePage={props.activePage}
-                    />
-                  </Segment>
-                  <Segment>
-                    <DropdownComponent
-                      customClass="page-limit"
-                      placeHolder="Show Rows"
-                      options={rowOptions}
-                      upward
-                      value={props.limit}
-                      onChange={props.handleRowChange}
-                    />
-                  </Segment>
-                </Segment.Group>
-              </Table.HeaderCell>
-            ) : ''}
-          </Table.Row>
-        </Table.Footer>
       </Table>
     </div>);
 };
 
 AssetsTableContent.propTypes = {
-  activePage: PropTypes.number,
-  activePageAssets: PropTypes.arrayOf(PropTypes.object),
-  emptyAssetsCheck: PropTypes.func.isRequired,
+  assets: PropTypes.arrayOf(PropTypes.object),
   errorMessage: PropTypes.string,
-  handlePageTotal: PropTypes.func,
-  handleRowChange: PropTypes.func,
-  handlePaginationChange: PropTypes.func,
   hasError: PropTypes.bool,
-  isLoading: PropTypes.bool,
-  limit: PropTypes.number
+  isLoading: PropTypes.bool
 };
 
 AssetsTableContent.defaultProps = {
   errorMessage: '',
-  isLoading: false
+  isLoading: false,
+  assets: [],
+  hasError: false
 };
+
 export default AssetsTableContent;

--- a/src/components/LoaderComponent.jsx
+++ b/src/components/LoaderComponent.jsx
@@ -1,11 +1,11 @@
 import React from 'react';
-import { Container, Dimmer, Grid } from 'semantic-ui-react';
+import { Segment, Dimmer, Grid } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 
 import '../_css/LoaderComponent.css';
 
 const LoaderComponent = ({ loadingText }) => (
-  <Container>
+  <Segment className="loader-segment">
     <Dimmer active inverted className="overlay">
       <Grid centered columns={3}>
         <Grid.Column className="loader-column">
@@ -18,7 +18,7 @@ const LoaderComponent = ({ loadingText }) => (
         </Grid.Column>
       </Grid>
     </Dimmer>
-  </Container>
+  </Segment>
 );
 
 LoaderComponent.propTypes = {

--- a/src/components/common/FilterButton.jsx
+++ b/src/components/common/FilterButton.jsx
@@ -1,6 +1,6 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import { Accordion, Icon, Menu, Popup } from 'semantic-ui-react';
+import { Accordion, Button, Icon, Menu, Popup } from 'semantic-ui-react';
 
 import ArtButton from './ButtonComponent';
 
@@ -34,13 +34,13 @@ class FilterButton extends React.Component {
         wide
         className="filter-popup"
         trigger={
-          <div
+          <Button
             className={this.state.toggleOn ? 'filter-button clicked' : 'filter-button'}
-            role="presentation"
+            disabled={this.props.disabled}
           >
             {this.state.toggleOn ? <Icon name="close" /> : <Icon name="bars" />}
             FILTERS
-          </div>
+          </Button>
         }
         on="click"
         open={this.state.toggleOn}
@@ -68,14 +68,16 @@ FilterButton.propTypes = {
   filterAction: PropTypes.func,
   activePage: PropTypes.number,
   limit: PropTypes.number,
-  selected: PropTypes.object
+  selected: PropTypes.object,
+  disabled: PropTypes.bool
 };
 
 FilterButton.defaultProps = {
   filterAction: () => {},
   activePage: 1,
   limit: 10,
-  selected: {}
+  selected: {},
+  disabled: false
 };
 
 export default FilterButton;

--- a/src/components/common/PaginationComponent.jsx
+++ b/src/components/common/PaginationComponent.jsx
@@ -1,0 +1,52 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import {
+  Pagination,
+  Segment
+} from 'semantic-ui-react';
+import rowOptions from '../../_utils/pageRowOptions';
+import DropdownComponent from './DropdownComponent';
+import '../../_css/PaginationComponent.css';
+
+const PaginationComponent = props => (
+  <Segment.Group
+    horizontal
+    id="art-pagination-section"
+    className={props.isLoading ? 'asset-loading-pagination' : 'asset-loaded-pagination'}
+  >
+    <Segment>
+      <Pagination
+        id="art-pagination-component"
+        totalPages={props.totalPages}
+        onPageChange={props.handlePaginationChange}
+        activePage={props.activePage}
+        disabled
+      />
+    </Segment>
+    <Segment>
+      <DropdownComponent
+        customClass="page-limit"
+        placeHolder="Show Rows"
+        options={rowOptions}
+        upward
+        value={props.limit}
+        onChange={props.handleRowChange}
+      />
+    </Segment>
+  </Segment.Group>
+);
+
+PaginationComponent.propTypes = {
+  activePage: PropTypes.number,
+  handleRowChange: PropTypes.func,
+  handlePaginationChange: PropTypes.func,
+  limit: PropTypes.number,
+  totalPages: PropTypes.number,
+  isLoading: PropTypes.bool
+};
+
+PaginationComponent.defaultProps = {
+  totalPages: 0
+};
+
+export default PaginationComponent;


### PR DESCRIPTION
## What does this PR do?
Makes changes to the loading spinner on the assets page as a UI improvement

## Description of Task to be completed?
- Make changes to the relevant components to enable the loading spinner to only cover the table
- The title as well as filter button (disabled during loading) should both show as the loader spins
- Pagination should be visible as the loader spins as well expect during the first load

## How should this be manually tested?
Once logged in, navigate to `assets`, observe the difference in the loader UI. Navigate to page 2 to view the pagination below the loading spinner as well.

## What are the relevant pivotal tracker stories?
[#161281468](https://www.pivotaltracker.com/n/projects/2146417/stories/161281468)

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
- First time load (filter button disabled and pagination not visible)
![screen shot 2018-10-31 at 13 35 35](https://user-images.githubusercontent.com/31322228/47789492-bda47400-dd25-11e8-98d3-cb235101e72b.png)

- After loading (filter button enabled and table has content)
![screen shot 2018-10-31 at 15 59 57](https://user-images.githubusercontent.com/31322228/47789667-373c6200-dd26-11e8-9dab-d6f9f35864f1.png)

- Loading 3rd page (filter button disabled and pagination viewable)
![screen shot 2018-10-31 at 16 00 10](https://user-images.githubusercontent.com/31322228/47789982-1aecf500-dd27-11e8-91d8-d0a56eebda20.png)

- Reloading first page (pagination now viewable since data was already loaded)
![screen shot 2018-10-31 at 16 00 21](https://user-images.githubusercontent.com/31322228/47790050-466fdf80-dd27-11e8-8527-2bd047e0ee64.png)
