### PR TITLE
#161920489 Fix asset number displayed in users table

### DIFF
--- a/src/components/User/UserComponent.jsx
+++ b/src/components/User/UserComponent.jsx
@@ -58,7 +58,7 @@ const UserComponent = (props) => {
 
               const updatedUser = {
                 ...user,
-                assets_assigned: user.allocated_asset_count
+                assets_assigned: user.allocated_assets.length
               };
 
               return (


### PR DESCRIPTION
## What does this PR do?

Fixes the inaccurate number of assigned assets being displayed on the user table

## Description of Task to be completed?

Implemented [here](https://github.com/AndelaOSP/art-dashboard/pull/161) - when you unassign an asset the asset count is not decremented.

### Acceptance Criteria

```gherkin
Scenario: An admin should see accurate number of assigned assets.
Given an admin with access
When I visit the user page
Then I should see accurate data on the assigned assets column
```

**Notes:**
This data should be reflected on the user details page.

## How should this be manually tested?

* Log in
* Navigate to the users page
* View the number of assigned assets in the assigned asset column to confirm if the numbers shown are accurate

## What are the relevant pivotal tracker stories?

[161920489](https://www.pivotaltracker.com/story/show/161920489)

## Any background context you want to add?

N/A

## Important notes

N/A

## Packages installed

N/A

## Deployment note

N/A

## Related PRs branch | PR (branch_name) | (pr_link)

N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots

<img width="1680" alt="screenshot 2018-10-31 at 12 05 05" src="https://user-images.githubusercontent.com/31339738/47777184-3e9f4380-dd05-11e8-9542-d255ea0c8e80.png">
