### PR TITLE
#162341806 Fix asset assignment bug

### DIFF
--- a/src/__test__/components/AssetDescriptionComponent.test.js
+++ b/src/__test__/components/AssetDescriptionComponent.test.js
@@ -2,9 +2,9 @@ import React from 'react';
 import { mount } from 'enzyme';
 import expect from 'expect';
 
-import AssetDescriptionComponent from '../components/AssetDescriptionComponent';
-import assetMocks from '../_mock/newAllocation';
-import assetSpecs from '../_mock/assetSpecs';
+import AssetDescriptionComponent from '../../components/AssetDescriptionComponent';
+import assetMocks from '../../_mock/newAllocation';
+import assetSpecs from '../../_mock/assetSpecs';
 
 describe('Renders <AssetDescriptionComponent /> correctly', () => {
   const props = {

--- a/src/__test__/components/AssignAssetComponent.test.js
+++ b/src/__test__/components/AssignAssetComponent.test.js
@@ -10,7 +10,8 @@ describe('Renders <AssignedTo /> correctly', () => {
     assignedUser: null,
     users: [],
     selectedUserId: null,
-    errorMessage: 'Could not assign the asset'
+    errorMessage: 'Could not assign the asset',
+    assetStatus: 'Available'
   };
   const wrapper = shallow(<AssignedTo {...props} />);
 

--- a/src/__test__/reducers/asset.reducer.test.js
+++ b/src/__test__/reducers/asset.reducer.test.js
@@ -85,6 +85,7 @@ describe('Asset Reducer tests', () => {
 
   it('should handle BUTTON_LOADING', () => {
     action.type = BUTTON_LOADING;
+    action.payload = true;
     expect(assetReducer(state, action).buttonLoading).toBe(true);
   });
 });

--- a/src/_actions/asset.actions.js
+++ b/src/_actions/asset.actions.js
@@ -90,7 +90,8 @@ export const reloadAssetDetail = assetSerialNumber => dispatch =>
 
 export const allocateAsset = (newAllocation, serialNumber) =>
   (dispatch) => {
-    dispatch({ type: BUTTON_LOADING });
+    dispatch(buttonLoading(true));
+
     return axios
       .post('allocations', newAllocation)
       .then((response) => {
@@ -100,15 +101,19 @@ export const allocateAsset = (newAllocation, serialNumber) =>
         });
         dispatch(reloadAssetDetail(serialNumber));
       })
-      .catch(error => dispatch({
-        type: NEW_ALLOCATION_FAILURE,
-        payload: error.message
-      }));
+      .catch((error) => {
+        dispatch({
+          type: NEW_ALLOCATION_FAILURE,
+          payload: error.message
+        });
+        dispatch(buttonLoading(false));
+      });
   };
 
 export const unassignAsset = (asset, serialNumber) =>
   (dispatch) => {
-    dispatch({ type: BUTTON_LOADING });
+    dispatch(buttonLoading(true));
+
     return axios
       .post('asset-status', asset)
       .then((response) => {
@@ -118,10 +123,13 @@ export const unassignAsset = (asset, serialNumber) =>
         });
         dispatch(reloadAssetDetail(serialNumber));
       })
-      .catch(error => dispatch({
-        type: UNASSIGN_FAILURE,
-        payload: error.message
-      }));
+      .catch((error) => {
+        dispatch({
+          type: UNASSIGN_FAILURE,
+          payload: error.message
+        });
+        dispatch(buttonLoading(false));
+      });
   };
 
 export const updateAsset = (assetSerialNumber, asset) => (dispatch) => {
@@ -140,3 +148,5 @@ export const updateAssetRequest = () => ({ type: UPDATE_ASSET_REQUEST });
 export const updateAssetSuccess = asset => ({ type: UPDATE_ASSET_SUCCESS, payload: asset });
 
 export const updateAssetFail = error => ({ type: UPDATE_ASSET_FAIL, payload: error });
+
+export const buttonLoading = loadState => ({ type: BUTTON_LOADING, payload: loadState });

--- a/src/_constants/index.js
+++ b/src/_constants/index.js
@@ -116,7 +116,9 @@ const CONSTANTS = KeyMirror({
   LOAD_LOCATIONS_FAILURE: true,
   UPDATE_ASSET_REQUEST: true,
   UPDATE_ASSET_SUCCESS: true,
-  UPDATE_ASSET_FAIL: true
+  UPDATE_ASSET_FAIL: true,
+  ASSET_AVAILABLE: 'Available',
+  ASSET_ALLOCATED: 'Allocated'
 });
 
 export default CONSTANTS;

--- a/src/_constants/index.js
+++ b/src/_constants/index.js
@@ -116,9 +116,10 @@ const CONSTANTS = KeyMirror({
   LOAD_LOCATIONS_FAILURE: true,
   UPDATE_ASSET_REQUEST: true,
   UPDATE_ASSET_SUCCESS: true,
-  UPDATE_ASSET_FAIL: true,
-  ASSET_AVAILABLE: 'Available',
-  ASSET_ALLOCATED: 'Allocated'
+  UPDATE_ASSET_FAIL: true
 });
+
+export const ASSET_AVAILABLE = 'Available';
+export const ASSET_ALLOCATED = 'Allocated';
 
 export default CONSTANTS;

--- a/src/_css/ModalComponent.scss
+++ b/src/_css/ModalComponent.scss
@@ -55,6 +55,14 @@
           margin-top: 20px;
         }
       }
+
+      .modal__buttons {
+        margin-top: 30px;
+
+        .save {
+          float: right;
+        }
+      }
     }
   }
 }

--- a/src/_reducers/asset.reducer.js
+++ b/src/_reducers/asset.reducer.js
@@ -42,7 +42,7 @@ export default (state = initialState.asset, action) => {
     case BUTTON_LOADING:
       return {
         ...state,
-        buttonLoading: true
+        buttonLoading: action.payload
       };
 
     case NEW_ALLOCATION_SUCCESS:

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -11,7 +11,11 @@ import ModalComponent from './common/ModalComponent';
 import ButtonComponent from '../components/common/ButtonComponent';
 import ConfirmAction from './common/ConfirmAction';
 import AssignedTo from './AssignAssetComponent';
+import constants from '../_constants';
+
 import '../_css/AssetDescriptionComponent.css';
+
+const { ASSET_AVAILABLE, ASSET_ALLOCATED } = constants;
 
 class AssetDescriptionComponent extends React.Component {
   state = {
@@ -110,7 +114,8 @@ class AssetDescriptionComponent extends React.Component {
     const triggerProps = this.triggerProps();
 
     const showAssignDropdown =
-      assetDetail.current_status === 'Available' || assetDetail.current_status === 'Allocated';
+      assetDetail.current_status === ASSET_AVAILABLE ||
+      assetDetail.current_status === ASSET_ALLOCATED;
 
     return (
       <Container>

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -11,11 +11,9 @@ import ModalComponent from './common/ModalComponent';
 import ButtonComponent from '../components/common/ButtonComponent';
 import ConfirmAction from './common/ConfirmAction';
 import AssignedTo from './AssignAssetComponent';
-import constants from '../_constants';
+import { ASSET_AVAILABLE, ASSET_ALLOCATED } from '../_constants';
 
 import '../_css/AssetDescriptionComponent.css';
-
-const { ASSET_AVAILABLE, ASSET_ALLOCATED } = constants;
 
 class AssetDescriptionComponent extends React.Component {
   state = {
@@ -136,8 +134,7 @@ class AssetDescriptionComponent extends React.Component {
               assetStatus={assetDetail.current_status}
             />
 
-            {
-              showAssignDropdown &&
+            {showAssignDropdown && (
               <ModalComponent
                 trigger={<ButtonComponent {...triggerProps} />}
                 modalTitle="Confirm Action"
@@ -149,7 +146,7 @@ class AssetDescriptionComponent extends React.Component {
                   buttonLoading={buttonLoading}
                 />
               </ModalComponent>
-            }
+            )}
           </Grid.Column>
         </Grid>
       </Container>
@@ -181,8 +178,7 @@ AssetDescriptionComponent.defaultProps = {
   assetAsigneeUsers: [],
   selectedUserId: 0,
   assignAssetButtonState: false,
-  handleConfirm: () => {
-  },
+  handleConfirm: () => {},
   buttonState: false,
   buttonLoading: false,
   specs: {},

--- a/src/components/AssetDescriptionComponent.jsx
+++ b/src/components/AssetDescriptionComponent.jsx
@@ -70,9 +70,12 @@ class AssetDescriptionComponent extends React.Component {
   };
 
   handleConfirm = () => {
-    if (isEmpty(values(this.props.assignedUser))) {
+    const { assignedUser } = this.props;
+
+    if (isEmpty(values(assignedUser))) {
       return this.handleAssign();
     }
+
     return this.handleUnassign();
   };
 
@@ -98,12 +101,16 @@ class AssetDescriptionComponent extends React.Component {
     const {
       assetAsigneeUsers,
       assignedUser,
-      toggleModal,
-      buttonLoading,
       assetDetail,
-      errorMessage
+      errorMessage,
+      toggleModal,
+      buttonLoading
     } = this.props;
+
     const triggerProps = this.triggerProps();
+
+    const showAssignDropdown =
+      assetDetail.current_status === 'Available' || assetDetail.current_status === 'Allocated';
 
     return (
       <Container>
@@ -121,18 +128,23 @@ class AssetDescriptionComponent extends React.Component {
               users={assetAsigneeUsers}
               selectedUserId={this.state.selectedUser}
               errorMessage={errorMessage}
+              assetStatus={assetDetail.current_status}
             />
-            <ModalComponent
-              trigger={<ButtonComponent {...triggerProps} />}
-              modalTitle="Confirm Action"
-            >
-              <ConfirmAction
-                toggleModal={toggleModal}
-                handleConfirm={this.handleConfirm}
-                buttonState={buttonLoading}
-                buttonLoading={buttonLoading}
-              />
-            </ModalComponent>
+
+            {
+              showAssignDropdown &&
+              <ModalComponent
+                trigger={<ButtonComponent {...triggerProps} />}
+                modalTitle="Confirm Action"
+              >
+                <ConfirmAction
+                  toggleModal={toggleModal}
+                  handleConfirm={this.handleConfirm}
+                  buttonState={buttonLoading}
+                  buttonLoading={buttonLoading}
+                />
+              </ModalComponent>
+            }
           </Grid.Column>
         </Grid>
       </Container>
@@ -164,7 +176,8 @@ AssetDescriptionComponent.defaultProps = {
   assetAsigneeUsers: [],
   selectedUserId: 0,
   assignAssetButtonState: false,
-  handleConfirm: () => {},
+  handleConfirm: () => {
+  },
   buttonState: false,
   buttonLoading: false,
   specs: {},

--- a/src/components/AssignAssetComponent.jsx
+++ b/src/components/AssignAssetComponent.jsx
@@ -11,6 +11,8 @@ const userEmailsOptions = usersList => usersList.map((typeOption, index) => ({
 }));
 
 const AssignedTo = (props) => {
+  const showAssignDropdown = props.assetStatus === 'Available' || props.assetStatus === 'Allocated';
+
   if (isEmpty(props.assignedUser)) {
     const hasError = !!props.errorMessage;
     const errorClass = hasError ? 'error' : '';
@@ -18,16 +20,21 @@ const AssignedTo = (props) => {
     return (
       <div id="allocate-asset">
         <Header as="h3" content="Assign this asset to:" />
-        <DropdownComponent
-          customClass={`form-dropdown ${errorClass}`}
-          label="Assign this asset to:"
-          placeHolder="Select Andela Email To Assign This Asset"
-          name="assign-user"
-          search
-          value={props.selectedUserId}
-          onChange={props.onSelectUserEmail}
-          options={userEmailsOptions(props.users)}
-        />
+        {
+          showAssignDropdown
+            ? <DropdownComponent
+              customClass={`form-dropdown ${errorClass}`}
+              label="Assign this asset to:"
+              placeHolder="Select Andela Email To Assign This Asset"
+              name="assign-user"
+              search
+              value={props.selectedUserId}
+              onChange={props.onSelectUserEmail}
+              options={userEmailsOptions(props.users)}
+            />
+            : <p>You cannot assign this asset. Only available assets can be assigned.</p>
+        }
+
         {
           hasError && (
             <p className="error-message">{props.errorMessage}</p>
@@ -55,12 +62,14 @@ AssignedTo.propTypes = {
   assignedUser: PropTypes.object,
   users: PropTypes.array,
   selectedUserId: PropTypes.number,
-  errorMessage: PropTypes.string
+  errorMessage: PropTypes.string,
+  assetStatus: PropTypes.string
 };
 
 AssignedTo.defaultProps = {
   errorMessage: '',
-  onSelectUserEmail: () => {},
+  onSelectUserEmail: () => {
+  },
   assignedUser: {},
   users: [],
   selectedUserId: null

--- a/src/components/AssignAssetComponent.jsx
+++ b/src/components/AssignAssetComponent.jsx
@@ -3,9 +3,7 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { Header } from 'semantic-ui-react';
 import DropdownComponent from '../components/common/DropdownComponent';
-import constants from '../_constants';
-
-const { ASSET_AVAILABLE, ASSET_ALLOCATED } = constants;
+import { ASSET_AVAILABLE, ASSET_ALLOCATED } from '../_constants';
 
 const userEmailsOptions = usersList => usersList.map((typeOption, index) => ({
   key: index,
@@ -24,20 +22,22 @@ const AssignedTo = (props) => {
     return (
       <div id="allocate-asset">
         <Header as="h3" content="Assign this asset to:" />
-        {
-          showAssignDropdown
-            ? <DropdownComponent
-              customClass={`form-dropdown ${errorClass}`}
-              label="Assign this asset to:"
-              placeHolder="Select Andela Email To Assign This Asset"
-              name="assign-user"
-              search
-              value={props.selectedUserId}
-              onChange={props.onSelectUserEmail}
-              options={userEmailsOptions(props.users)}
-            />
-            : <p>You cannot assign this asset. Only available assets can be assigned.</p>
-        }
+        {showAssignDropdown && (
+          <DropdownComponent
+            customClass={`form-dropdown ${errorClass}`}
+            label="Assign this asset to:"
+            placeHolder="Select Andela Email To Assign This Asset"
+            name="assign-user"
+            search
+            value={props.selectedUserId}
+            onChange={props.onSelectUserEmail}
+            options={userEmailsOptions(props.users)}
+          />
+        )}
+
+        {!showAssignDropdown && (
+          <p>You cannot assign this asset. Only available assets can be assigned.</p>
+        )}
 
         {
           hasError && (
@@ -72,8 +72,7 @@ AssignedTo.propTypes = {
 
 AssignedTo.defaultProps = {
   errorMessage: '',
-  onSelectUserEmail: () => {
-  },
+  onSelectUserEmail: () => {},
   assignedUser: {},
   users: [],
   selectedUserId: null

--- a/src/components/AssignAssetComponent.jsx
+++ b/src/components/AssignAssetComponent.jsx
@@ -3,6 +3,9 @@ import PropTypes from 'prop-types';
 import { isEmpty } from 'lodash';
 import { Header } from 'semantic-ui-react';
 import DropdownComponent from '../components/common/DropdownComponent';
+import constants from '../_constants';
+
+const { ASSET_AVAILABLE, ASSET_ALLOCATED } = constants;
 
 const userEmailsOptions = usersList => usersList.map((typeOption, index) => ({
   key: index,
@@ -11,7 +14,8 @@ const userEmailsOptions = usersList => usersList.map((typeOption, index) => ({
 }));
 
 const AssignedTo = (props) => {
-  const showAssignDropdown = props.assetStatus === 'Available' || props.assetStatus === 'Allocated';
+  const showAssignDropdown =
+    props.assetStatus === ASSET_AVAILABLE || props.assetStatus === ASSET_ALLOCATED;
 
   if (isEmpty(props.assignedUser)) {
     const hasError = !!props.errorMessage;

--- a/src/components/common/ConfirmAction.jsx
+++ b/src/components/common/ConfirmAction.jsx
@@ -5,6 +5,7 @@ import ButtonComponent from './ButtonComponent';
 export default class ConfirmAction extends React.Component {
   componentDidUpdate(prevProps) {
     const { buttonLoading, toggleModal } = this.props;
+
     if ((prevProps.buttonLoading !== buttonLoading) && !buttonLoading) {
       toggleModal();
     }
@@ -16,19 +17,22 @@ export default class ConfirmAction extends React.Component {
         <label>
           Are you sure you want to perform this action?
         </label>
-        <br />
-        <ButtonComponent
-          className="cancel"
-          buttonName="Cancel"
-          handleClick={this.props.toggleModal}
-        />
-        <ButtonComponent
-          className="save"
-          buttonName="Save"
-          color="primary"
-          buttonState={this.props.buttonState}
-          handleClick={this.props.handleConfirm}
-        />
+
+        <div className="modal__buttons">
+          <ButtonComponent
+            customCss="cancel"
+            buttonName="Cancel"
+            handleClick={this.props.toggleModal}
+          />
+
+          <ButtonComponent
+            customCss="save"
+            buttonName="Save"
+            color="primary"
+            buttonState={this.props.buttonState}
+            handleClick={this.props.handleConfirm}
+          />
+        </div>
       </Fragment>
     );
   }

--- a/src/components/common/ModalComponent.jsx
+++ b/src/components/common/ModalComponent.jsx
@@ -1,5 +1,5 @@
 import React, { Component } from 'react';
-import { Modal } from 'semantic-ui-react';
+import { Modal, TransitionablePortal } from 'semantic-ui-react';
 import PropTypes from 'prop-types';
 import { SemanticToastContainer } from 'react-semantic-toasts';
 
@@ -11,49 +11,44 @@ export default class ArtModal extends Component {
   toggleModal = () => this.setState({ modalOpen: !this.state.modalOpen });
 
   render() {
-    const { children } = this.props;
+    const { children, closeIcon, closeOnEscape, closeOnDimmerClick, modalSize } = this.props;
+    const { modalOpen } = this.state;
+
     const childrenWithProps = React.Children.map(children, child =>
       React.cloneElement(child,
         { toggleModal: this.toggleModal }
       )
     );
+
     return (
       <span className={this.props.className}>
-        <Modal
-          className="art-modal"
-          trigger={
-            this.props.trigger ? (
-              <span
-                tabIndex="-1"
-                role="button"
-                onClick={this.toggleModal}
-                onKeyUp={(() => {})}
-              >
-                {this.props.trigger}
-              </span>
-            ) : (
-              <i
-                className="plus link icon"
-                onClick={this.toggleModal}
-                onKeyUp={() => {}}
-                role="button"
-                tabIndex="-1"
-              />
-            )}
-          open={this.state.modalOpen}
-          onClose={this.toggleModal}
-          size={this.props.modalSize}
-          closeIcon={this.props.closeIcon}
-          closeOnEscape={this.props.closeOnEscape}
-          closeOnDimmerClick={this.props.closeOnDimmerClick}
+        <span
+          tabIndex="-1"
+          role="button"
+          onClick={this.toggleModal}
+          onKeyUp={() => {}}
         >
-          <Modal.Header>{this.props.modalTitle} <div className="underline" /></Modal.Header>
-          <Modal.Content>
-            <Modal.Description style={{ width: '100%' }}>
-              {childrenWithProps}
-            </Modal.Description>
-          </Modal.Content>
-        </Modal>
+          {this.props.trigger}
+        </span>
+
+        <TransitionablePortal open={modalOpen} transition={{ animation: 'scale', duration: 500 }}>
+          <Modal
+            className="art-modal"
+            open={modalOpen}
+            onClose={this.toggleModal}
+            size={modalSize}
+            closeIcon={closeIcon}
+            closeOnEscape={closeOnEscape}
+            closeOnDimmerClick={closeOnDimmerClick}
+          >
+            <Modal.Header>{this.props.modalTitle} <div className="underline" /></Modal.Header>
+            <Modal.Content>
+              <Modal.Description style={{ width: '100%' }}>
+                {childrenWithProps}
+              </Modal.Description>
+            </Modal.Content>
+          </Modal>
+        </TransitionablePortal>
         <SemanticToastContainer />
       </span>
     );


### PR DESCRIPTION
## What does this PR do?

Fixes a bug where if an asset was damaged or lost, it would still render the asset allocation dropdown but fail to assign the asset since only available assets can be assigned. 

## Description of Task to be completed?

```gherkin
Scenario: An asset can only be assigned if its status is `Available`.
Given a damaged or lost asset
When I want to assign it 
Then I should see a message telling me that only available assets can be assigned.
```

## How should this be manually tested?

* Log in to the app
* Click the Assets link
* Select an asset whose status is either damaged or lost. You should be presented with a message instead of the dropdown

## What are the relevant pivotal tracker stories?

[162341806](https://www.pivotaltracker.com/story/show/162341806)

## Any background context you want to add?

N/A

## Important notes

* Added some tweaks to improve the modal aesthetics

## Packages installed

N/A

## Deployment note

N/A

## Related PRs branch | PR (branch_name) | (pr_link)

N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots

<img width="1680" alt="screenshot 2018-12-03 at 12 38 21" src="https://user-images.githubusercontent.com/31339738/49365660-6c0e5100-f6f8-11e8-821a-fdba977e45b6.png">

<img width="1680" alt="screenshot 2018-12-03 at 12 38 50" src="https://user-images.githubusercontent.com/31339738/49365712-87795c00-f6f8-11e8-94ed-ed2208cded4c.png">

