### PR TITLE
#162248159 Add a link on the asset table row

### DIFF
--- a/src/components/User/UserDetailComponent.jsx
+++ b/src/components/User/UserDetailComponent.jsx
@@ -39,6 +39,7 @@ const assetsAssigned = (allocatedAssets) => {
             <TableRowDetail
               key={asset.id}
               data={asset}
+              viewDetailsRoute={`/assets/${asset.uuid}/view`}
               headings={[
                 'asset_type',
                 'asset_code',


### PR DESCRIPTION
## What does this PR do?

Makes the asset list on user details page clickable.

## Description of Task to be completed?

```gherkin
Scenario: Asset list on user details page
Given A logged in user
When I visit the user details page
And I click on one of the assets assigned to that user
Then I should see the details of that asset.
```

## How should this be manually tested?

* Log in
* Click on the `Users` link
* Click on one of the users that have assets assigned to them
* Click on one of the assets and you should be redirected to the asset's detail page

## What are the relevant pivotal tracker stories?

[162248159](https://www.pivotaltracker.com/story/show/162248159)

## Any background context you want to add?

N/A

## Important notes

N/A

## Packages installed

N/A

## Deployment note

N/A

## Related PRs branch | PR (branch_name) | (pr_link)

N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots

![clickable asset list](https://user-images.githubusercontent.com/31339738/49422886-8b63b780-f7a6-11e8-9781-34ae160a6d43.gif)
