### PR TITLE
Admin can see user assigned to asset 162248110

### DIFF
--- a/src/__test__/actions/asset.actions.test.js
+++ b/src/__test__/actions/asset.actions.test.js
@@ -161,7 +161,7 @@ describe('Asset Action tests', () => {
         expect(store.getActions()[1].type).toEqual(NEW_ALLOCATION_SUCCESS);
         mock.onGet().reply(200, loadedAsset);
         return store.dispatch(reloadAssetDetail()).then(() => {
-          expect(store.getActions()[2].type).toEqual(LOAD_ASSET_SUCCESS);
+          expect(store.getActions()[3].type).toEqual(LOAD_ASSET_SUCCESS);
         });
       });
   });

--- a/src/__test__/actions/asset.actions.test.js
+++ b/src/__test__/actions/asset.actions.test.js
@@ -161,7 +161,10 @@ describe('Asset Action tests', () => {
         expect(store.getActions()[1].type).toEqual(NEW_ALLOCATION_SUCCESS);
         mock.onGet().reply(200, loadedAsset);
         return store.dispatch(reloadAssetDetail()).then(() => {
-          expect(store.getActions()[2].type).toEqual(LOAD_ASSET_SUCCESS);
+          expect(store.getActions()).toContainEqual({
+            type: LOAD_ASSET_SUCCESS,
+            payload: loadedAsset
+          });
         });
       });
   });

--- a/src/__test__/actions/asset.actions.test.js
+++ b/src/__test__/actions/asset.actions.test.js
@@ -161,7 +161,7 @@ describe('Asset Action tests', () => {
         expect(store.getActions()[1].type).toEqual(NEW_ALLOCATION_SUCCESS);
         mock.onGet().reply(200, loadedAsset);
         return store.dispatch(reloadAssetDetail()).then(() => {
-          expect(store.getActions()[3].type).toEqual(LOAD_ASSET_SUCCESS);
+          expect(store.getActions()[2].type).toEqual(LOAD_ASSET_SUCCESS);
         });
       });
   });

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -40,8 +40,7 @@ const AssetsTableContent = (props) => {
             <Table.HeaderCell>Model Number</Table.HeaderCell>
             <Table.HeaderCell>Asset Make</Table.HeaderCell>
             <Table.HeaderCell>Asset Type</Table.HeaderCell>
-            <Table.HeaderCell>Category</Table.HeaderCell>
-            <Table.HeaderCell>Sub-category</Table.HeaderCell>
+            <Table.HeaderCell>Assigned To</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
 
@@ -53,7 +52,10 @@ const AssetsTableContent = (props) => {
               ...asset,
               asset_code: asset.asset_code || '-',
               serial_number: asset.serial_number || '-',
-              model_number: asset.model_number || '-'
+              model_number: asset.model_number || '-',
+              assignee: (asset.assigned_to && asset.assigned_to.email)
+                || (asset.assigned_to && `${asset.assigned_to.full_name}`)
+                || '-'
             };
 
             return (
@@ -67,8 +69,7 @@ const AssetsTableContent = (props) => {
                   'model_number',
                   'make_label',
                   'asset_type',
-                  'asset_category',
-                  'asset_sub_category'
+                  'assignee'
                 ]}
               />
             );


### PR DESCRIPTION
## What does this PR do?
- Shows the email (or full name) of user that an asset is assigned to

## Description of Task to be completed?
- Admin can see user assigned to asset on asset list page
- Removes category and sub-category columns from assets list table

## How should this be manually tested?
- Go to the assets list page. On the table you should see the email (or full name) of a user that an asset has been assigned to

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162248110

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots