### PR TITLE
Bg filters unapplied after pagination 162474348

### DIFF
--- a/src/components/AssetsComponent.jsx
+++ b/src/components/AssetsComponent.jsx
@@ -8,10 +8,11 @@ import FilterButton from './common/FilterButton';
 import FilterComponent from './common/FilterComponent';
 import PaginationComponent from './common/PaginationComponent';
 import { isCountCutoffExceeded, fetchData } from '../_utils/helpers';
+import { constructUrl } from '../_utils/assets';
 
 import '../_css/AssetsComponent.css';
 
-const CUTOFF_LIMIT = 50;
+const CUTOFF_LIMIT = 100;
 const checkIfCutoffExceeded = isCountCutoffExceeded(CUTOFF_LIMIT);
 
 export default class AssetsComponent extends Component {
@@ -59,26 +60,25 @@ export default class AssetsComponent extends Component {
   };
 
   handlePaginationChange = (e, { activePage }) => {
-    const { match } = this.props;
+    const { match, selected } = this.props;
     const { status } = match.params;
 
     this.props.setActivePage(activePage);
-    const filters = this.props.selected;
+    const currentPageList = this.props.assetsList[`page_${activePage}`];
 
-    if (filters) {
-      this.props.getAssetsAction(activePage, this.state.limit, filters);
-    } else {
-      const currentPageList = this.props.assetsList[`page_${activePage}`];
-
-      if (isEmpty(currentPageList)) {
-        this.retrieveAssets(activePage, this.state.limit, status);
-      }
+    if (isEmpty(currentPageList)) {
+      this.retrieveAssets(
+        activePage,
+        this.state.limit,
+        status,
+        selected
+      );
     }
   };
 
-  retrieveAssets = (activePage, limit, status) => {
+  retrieveAssets = (activePage, limit, status, filters = {}) => {
     if (checkIfCutoffExceeded(activePage, limit)) {
-      const url = `manage-assets?page=${activePage}&page_size=${limit}&current_status=${status}`;
+      const url = constructUrl(activePage, limit, filters, status);
 
       this.props.loading(true);
       return fetchData(url).then((response) => {
@@ -87,7 +87,7 @@ export default class AssetsComponent extends Component {
       });
     }
 
-    return this.loadAssets(activePage, limit, null, status);
+    return this.loadAssets(activePage, limit, filters, status);
   };
 
   handlePageTotal = () => Math.ceil(this.props.assetsCount / this.state.limit);

--- a/src/components/AssetsComponent.jsx
+++ b/src/components/AssetsComponent.jsx
@@ -63,10 +63,16 @@ export default class AssetsComponent extends Component {
     const { status } = match.params;
 
     this.props.setActivePage(activePage);
-    const currentPageList = this.props.assetsList[`page_${activePage}`];
+    const filters = this.props.selected;
 
-    if (isEmpty(currentPageList)) {
-      this.retrieveAssets(activePage, this.state.limit, status);
+    if (filters) {
+      this.props.getAssetsAction(activePage, this.state.limit, filters);
+    } else {
+      const currentPageList = this.props.assetsList[`page_${activePage}`];
+
+      if (isEmpty(currentPageList)) {
+        this.retrieveAssets(activePage, this.state.limit, status);
+      }
     }
   };
 

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -60,7 +60,7 @@ const AssetsTableContent = (props) => {
               serial_number: asset.serial_number || '-',
               model_number: asset.model_number || '-',
               assignee: (asset.assigned_to && asset.assigned_to.email)
-                || (asset.assigned_to && `${asset.assigned_to.full_name}`)
+                || (asset.assigned_to && asset.assigned_to.full_name)
                 || '-'
             };
 

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -60,7 +60,7 @@ const AssetsTableContent = (props) => {
               serial_number: asset.serial_number || '-',
               model_number: asset.model_number || '-',
               assignee: (asset.assigned_to && asset.assigned_to.email)
-                || (asset.assigned_to && asset.assigned_to.full_name)
+                || (asset.assigned_to && `${asset.assigned_to.full_name}`)
                 || '-'
             };
 


### PR DESCRIPTION
## What does this PR do?
Applies filters after pagination change

## Description of Task to be completed?
Ensure that after pagination change, filters are still applied if there any

## How should this be manually tested?
Go to the assets list table and apply a filter. Then change to another page, filter(s) should still be applied after pagination change

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162474348

## Any background context you want to add?
N/A

## Important notes

## Packages installed

## Deployment note

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots