### PR TITLE
bg fix asset assigned to non email assignees showing as undefined in asset list table

### DIFF
--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -8,6 +8,13 @@ import LoaderComponent from './LoaderComponent';
 import { ToastMessage } from '../_utils/ToastMessage';
 import NotFound from './common/ItemsNotFoundComponent';
 
+const getAssignee = (data) => {
+  if (!data) {
+    return '-';
+  }
+  return data.email || data.full_name || data.name || '-';
+};
+
 const AssetsTableContent = (props) => {
   const { assets, status, errorMessage, hasError, isLoading } = props;
 
@@ -59,9 +66,7 @@ const AssetsTableContent = (props) => {
               asset_code: asset.asset_code || '-',
               serial_number: asset.serial_number || '-',
               model_number: asset.model_number || '-',
-              assignee: (asset.assigned_to && asset.assigned_to.email)
-                || (asset.assigned_to && `${asset.assigned_to.full_name}`)
-                || '-'
+              assignee: getAssignee(asset.assigned_to)
             };
 
             return (


### PR DESCRIPTION
## What does this PR do?
Fixes asset assigned to non email assignees showing as `undefined` in asset list table

## Description of Task to be completed?
Same as 👆🏽

## How should this be manually tested?
The `assigned_to` column on the assets list table should no longer show `undefined`

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162481628

## Any background context you want to add?

## Important notes

## Packages installed

## Deployment note

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots