### PR TITLE
bug(user-filter): keep filters applied after row change

### DIFF
--- a/src/_actions/users.actions.js
+++ b/src/_actions/users.actions.js
@@ -1,6 +1,7 @@
 import axios from 'axios';
 import { isEmpty } from 'lodash';
 import { fetchData } from '../_utils/helpers';
+import constructUrl from '../_utils/constructUrl';
 import constants from '../_constants';
 import { updateToastMessageContent } from './toastMessage.actions';
 
@@ -15,15 +16,6 @@ const {
   SET_USERS_ACTIVE_PAGE,
   RESET_STATUS_MESSAGE
 } = constants;
-
-const constructUrl = (pageNumber, limit, filters = {}) => {
-  let url = `users?page=${pageNumber}&page_size=${limit}`;
-
-  if (!isEmpty(filters)) {
-    url = `${url}&asset_count=${filters['Asset Assigned'] || ''}&cohort=${filters.Cohort || ''}`;
-  }
-  return url;
-};
 
 export const loadUsers = (pageNumber, limit, filters = {}) => (dispatch) => {
   dispatch(loading(true));

--- a/src/_components/User/UserContainer.jsx
+++ b/src/_components/User/UserContainer.jsx
@@ -3,7 +3,7 @@ import { loadAllFilterValues } from '../../_actions/allFilterValues.actions';
 import { loadUsers, setActivePage, resetUsers, loading, resetMessage } from '../../_actions/users.actions';
 import User from '../../components/User/UserComponent';
 
-export const mapStateToProps = ({ usersList }) => {
+export const mapStateToProps = ({ usersList, selected }) => {
   const {
     activePage,
     users,
@@ -20,7 +20,8 @@ export const mapStateToProps = ({ usersList }) => {
     hasError,
     isLoading,
     activePage,
-    isFiltered
+    isFiltered,
+    selected
   };
 };
 

--- a/src/_utils/constructUrl.js
+++ b/src/_utils/constructUrl.js
@@ -1,0 +1,12 @@
+import { isEmpty } from 'lodash';
+
+const constructUrl = (pageNumber, limit, filters = {}) => {
+  let url = `users?page=${pageNumber}&page_size=${limit}`;
+
+  if (!isEmpty(filters)) {
+    url = `${url}&asset_count=${filters['Asset Assigned'] || ''}&cohort=${filters.Cohort || ''}`;
+  }
+  return url;
+};
+
+export default constructUrl;

--- a/src/components/User/UserComponent.jsx
+++ b/src/components/User/UserComponent.jsx
@@ -11,6 +11,7 @@ import ItemsNotFoundComponent from '../common/ItemsNotFoundComponent';
 import UserHeader from './UserHeader';
 import StatusMessageComponent from '../common/StatusComponent';
 import { isCountCutoffExceeded, fetchData } from '../../_utils/helpers';
+import constructUrl from '../../_utils/constructUrl';
 
 import '../../_css/UsersComponent.css';
 
@@ -33,27 +34,27 @@ export default class UserComponent extends React.Component {
   }
 
   handleRowChange = (e, data) => {
+    const { activePage, selected } = this.props;
     this.setState({
       limit: data.value,
       users: []
     });
     this.props.resetUsers();
-    this.retrieveUsers(this.props.activePage, data.value);
+    this.retrieveUsers(activePage, data.value, selected);
   };
 
   handlePaginationChange = (e, { activePage }) => {
     this.props.setActivePage(activePage);
     const currentPageList = this.props.users[`page_${activePage}`];
     if (isEmpty(currentPageList)) {
-      this.retrieveUsers(activePage, this.state.limit);
+      this.retrieveUsers(activePage, this.state.limit, this.props.selected);
     }
   };
 
-  retrieveUsers = (activePage, limit) => {
+  retrieveUsers = (activePage, limit, filters) => {
     if (checkIfCutoffExceeded(activePage, limit)) {
-      const url = `users?page=${activePage}&page_size=${limit}`;
       this.props.loading(true);
-      return fetchData(url).then((response) => {
+      return fetchData(constructUrl(activePage, limit, filters)).then((response) => {
         this.props.loading(false);
         this.setState({ users: response.data.results });
       }).catch(() => {
@@ -61,7 +62,7 @@ export default class UserComponent extends React.Component {
         this.setState({ allDataFetched: true });
       });
     }
-    return this.props.loadUsers(activePage, limit);
+    return this.props.loadUsers(activePage, limit, filters);
   };
 
   handlePageTotal = () => Math.ceil(this.props.usersCount / this.state.limit);
@@ -191,7 +192,8 @@ UserComponent.propTypes = {
   setActivePage: PropTypes.func,
   loading: PropTypes.func,
   resetMessage: PropTypes.func,
-  isFiltered: PropTypes.bool
+  isFiltered: PropTypes.bool,
+  selected: PropTypes.object
 };
 
 UserComponent.defaultProps = {


### PR DESCRIPTION
## What does this PR do?
Retains the filters applied even after row change

## Description of Task to be completed?
- Refactor `retrieveUsers` within UserComponent

## How should this be manually tested?
- Head on to the `User List` page, click on the filter button to filter by any option of choice. 
- Click on the pagination row change drop down to change the number of rows being displayed. You should see users under the filter option you applied at the beginning.

## What are the relevant pivotal tracker stories?
[#162500589](https://www.pivotaltracker.com/n/projects/2146417/stories/162500589)

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
N/A