### PR TITLE
feat(assets): admin can mark assets as verified/unverified

### DIFF
--- a/src/__test__/components/AssetVerifiedComponent.test.js
+++ b/src/__test__/components/AssetVerifiedComponent.test.js
@@ -1,0 +1,78 @@
+import React from 'react';
+import { shallow } from 'enzyme';
+import expect from 'expect';
+
+import AssetVerifiedComponent from '../../components/AssetDetails/AssetVerifiedComponent';
+
+import { asset } from '../../_mock/asset';
+
+describe('Render AssetVerifiedComponent correctly', () => {
+  const props = {
+    assetDetail: asset,
+    updateLoading: false,
+    updateAsset: async () => {},
+    uuid: asset.uuid
+  };
+
+  const wrapper = shallow(<AssetVerifiedComponent {...props} />);
+
+  it('calls handleDropdownChange function', () => {
+    const handleDropdownChangeSpy = jest.spyOn(
+      wrapper.instance(), 'handleDropdownChange'
+    );
+
+    const event = {
+      stopPropagation: jest.fn()
+    };
+    const data = {};
+
+    wrapper.instance().handleDropdownChange(event, data);
+    expect(handleDropdownChangeSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls toggleFormVisibility function', () => {
+    const toggleFormVisibilitySpy = jest.spyOn(
+      wrapper.instance(), 'toggleFormVisibility'
+    );
+
+    wrapper.instance().toggleFormVisibility();
+    expect(toggleFormVisibilitySpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the updateVerifiedStatus function', () => {
+    const updateVerifiedStatusSpy = jest.spyOn(
+      wrapper.instance(), 'updateVerifiedStatus'
+    );
+
+    wrapper.instance().updateVerifiedStatus();
+    expect(updateVerifiedStatusSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('changes optionText state to Yes if value.data is Yes', () => {
+    wrapper.setState({ optionText: 'No' });
+
+    const event = {
+      stopPropagation: jest.fn()
+    };
+    const data = {
+      value: 'Yes'
+    };
+
+    wrapper.instance().handleDropdownChange(event, data);
+    expect(wrapper.state().optionText).toEqual('Yes');
+  });
+
+  it('changes optionText state to No if value.data is No', () => {
+    wrapper.setState({ optionText: 'Yes' });
+
+    const event = {
+      stopPropagation: jest.fn()
+    };
+    const data = {
+      value: 'No'
+    };
+
+    wrapper.instance().handleDropdownChange(event, data);
+    expect(wrapper.state().optionText).toEqual('No');
+  });
+});

--- a/src/_css/AssetDetailsComponent.scss
+++ b/src/_css/AssetDetailsComponent.scss
@@ -55,6 +55,7 @@
         }
       }
     }
+  }
 
     .loading.form {
       min-height: 25px;
@@ -64,7 +65,6 @@
       width: 2em;
       height: 2em;
     }
-  }
 }
 
 .ui.dropdown.form-dropdown.asset-detail__table__dropdown > .dropdown.icon {

--- a/src/components/AssetDetails/AssetDetailsComponent.jsx
+++ b/src/components/AssetDetails/AssetDetailsComponent.jsx
@@ -18,6 +18,7 @@ import NavBarComponent from '../../_components/NavBarContainer';
 import LoaderComponent from '../LoaderComponent';
 import StatusMessageComponent from '../common/StatusComponent';
 import OfficeLocations from '../../_components/OfficeLocations/OfficeLocationsContainer';
+import AssetVerifiedComponent from './AssetVerifiedComponent';
 
 import '../../_css/AssetDetailsComponent.css';
 
@@ -50,7 +51,14 @@ class AssetDetailsComponent extends Component {
   }
 
   render() {
-    const { assetDetail, errorMessage, success, updateErrorMessage, match } = this.props;
+    const {
+      assetDetail,
+      errorMessage,
+      success,
+      updateErrorMessage,
+      match,
+      updateAsset
+    } = this.props;
 
     const showMessage = success || updateErrorMessage;
 
@@ -174,6 +182,12 @@ class AssetDetailsComponent extends Component {
                             <Table.Cell className="details-headings">Asset Status</Table.Cell>
                             <Table.Cell>{assetDetail.current_status || '-'}</Table.Cell>
                           </Table.Row>
+
+                          <AssetVerifiedComponent
+                            uuid={match.params.id}
+                            assetDetail={assetDetail}
+                            updateAsset={updateAsset}
+                          />
                         </Table.Body>
                       </Table>
                     </Grid.Column>

--- a/src/components/AssetDetails/AssetVerifiedComponent.jsx
+++ b/src/components/AssetDetails/AssetVerifiedComponent.jsx
@@ -1,0 +1,108 @@
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
+import { Form, Icon, Table } from 'semantic-ui-react';
+
+import DropdownComponent from '../common/DropdownComponent';
+
+class AssetVerifiedComponent extends Component {
+  state = {
+    show: false,
+    isChecked: this.props.assetDetail.verified,
+    optionText: this.props.assetDetail.verified ? 'Yes' : 'No'
+  };
+
+  handleDropdownChange = (event, data) => {
+    event.stopPropagation();
+
+    const dropdownValue = data.value === 'Yes';
+
+    this.setState({
+      isChecked: dropdownValue,
+      optionText: data.value
+    });
+  };
+
+  toggleFormVisibility = () => {
+    this.setState({
+      show: !this.state.show
+    });
+  };
+
+  updateVerifiedStatus = () => {
+    const { assetDetail, updateAsset, uuid } = this.props;
+    const { asset_code, model_number, serial_number, verified } = assetDetail; // eslint-disable-line
+
+    updateAsset(uuid, {
+      model_number,
+      asset_code,
+      serial_number,
+      verified: this.state.isChecked
+    }).then(() => {
+      this.toggleFormVisibility();
+    });
+  };
+
+  render() {
+    const { updateLoading } = this.props;
+    const { show, optionText } = this.state;
+
+    if (!show) {
+      return (
+        <Table.Row>
+          <Table.Cell className="details-headings">Verified</Table.Cell>
+          <Table.Cell>
+            {optionText}
+            <Icon
+              name="edit"
+              className="asset-detail__table__icon"
+              onClick={this.toggleFormVisibility}
+            />
+          </Table.Cell>
+        </Table.Row>
+      );
+    }
+
+    return (
+      <Table.Row>
+        <Table.Cell className="details-headings">Verified</Table.Cell>
+        <Table.Cell>
+          <Form loading={updateLoading}>
+
+            <DropdownComponent
+              customClass="form-dropdown asset-detail__table__dropdown"
+              label="Verified"
+              options={[{ text: 'Yes', value: 'Yes' }, { text: 'No', value: 'No' }]}
+              placeholder="Select Verification Status"
+              name="assetVerified"
+              value={optionText}
+              onChange={this.handleDropdownChange}
+              upward={false}
+            />
+
+            <Icon
+              name="close"
+              className="asset-detail__table__icon"
+              onClick={this.toggleFormVisibility}
+            />
+
+            <Icon
+              name="save"
+              className="asset-detail__table__icon"
+              onClick={this.updateVerifiedStatus}
+            />
+
+          </Form>
+        </Table.Cell>
+      </Table.Row>
+    );
+  }
+}
+
+AssetVerifiedComponent.propTypes = {
+  updateAsset: PropTypes.func,
+  assetDetail: PropTypes.object,
+  uuid: PropTypes.string,
+  updateLoading: PropTypes.bool
+};
+
+export default AssetVerifiedComponent;

--- a/src/components/common/CheckboxComponent.jsx
+++ b/src/components/common/CheckboxComponent.jsx
@@ -3,15 +3,24 @@ import PropTypes from 'prop-types';
 
 import '../../_css/CheckboxComponent.css';
 
-const CheckboxComponent = ({ isChecked = false, label, name, handleCheckboxChange }) => (
+const CheckboxComponent = ({
+  isChecked = false,
+  label,
+  name,
+  handleCheckboxChange,
+  disabled,
+  customClass
+}) => (
   <div className="field">
     <div className="ui checkbox">
       <input
         type="checkbox"
         name={name}
+        disabled={disabled}
         value={label}
         onChange={handleCheckboxChange}
         checked={isChecked}
+        className={customClass}
       />
       <label className="check label">{label}</label>
     </div>
@@ -25,7 +34,9 @@ CheckboxComponent.propTypes = {
   ]),
   name: PropTypes.string.isRequired,
   isChecked: PropTypes.bool,
-  handleCheckboxChange: PropTypes.func
+  handleCheckboxChange: PropTypes.func,
+  disabled: PropTypes.bool,
+  customClass: PropTypes.string
 };
 
 export default CheckboxComponent;

--- a/src/components/common/DropdownComponent.jsx
+++ b/src/components/common/DropdownComponent.jsx
@@ -30,7 +30,8 @@ DropdownComponent.propTypes = {
   upward: PropTypes.bool,
   value: PropTypes.oneOfType([
     PropTypes.string,
-    PropTypes.number
+    PropTypes.number,
+    PropTypes.bool
   ])
 };
 


### PR DESCRIPTION
## What does this PR do?
Enables an Admin to mark assets as verified/unverified

## Description of Task to be completed?
- add AssetVerifiedStatusComponent
- add css styling
- add relevant tests

## How should this be manually tested?
Head on to the `Assets List` page, click on a single asset, on the field labeled `Verified` click on the edit button to change its status to verified or unverified.

## What are the relevant pivotal tracker stories?
[#162078804](https://www.pivotaltracker.com/n/projects/2146417/stories/162078804)

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
![screen recording 2018-12-13 at 02 06 pm](https://user-images.githubusercontent.com/31322228/49934832-7ee70980-fee0-11e8-8dba-5ec99f47f68e.gif)
