### PR TITLE
Make the create asset route come before the optional one

### DIFF
--- a/src/_components/RoutesComponent.jsx
+++ b/src/_components/RoutesComponent.jsx
@@ -61,6 +61,12 @@ class RoutesComponent extends Component {
           <Authenticate
             exact
             isAuthenticated={this.checkAuthentication()}
+            path="/assets/create"
+            component={AddAsset}
+          />
+          <Authenticate
+            exact
+            isAuthenticated={this.checkAuthentication()}
             path="/assets/:status?"
             component={Assets}
           />
@@ -133,12 +139,6 @@ class RoutesComponent extends Component {
             isAuthenticated={this.checkAuthentication()}
             path="/asset-specs/create"
             component={AddAssetSpec}
-          />
-          <Authenticate
-            exact
-            isAuthenticated={this.checkAuthentication()}
-            path="/assets/create"
-            component={AddAsset}
           />
           <Route exact path="/" component={LoginComponent} />
           <Route path="*" component={PageNotFound} />


### PR DESCRIPTION
## What does this PR do?
Moves the `assets/create` before `assets/:status?`

## Description of Task to be completed?
Clicking the `Add Asset` button was rendering the "not found" UI instead of the necessary form. This PR fixes the issue

## How should this be manually tested?
- Click `Add Asset` button and ensure that the form gets rendered
- Verify that `/assets/allocated`, `/assets`, `/assets/lost`, etc routes still work as intended

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/n/projects/2146417/stories/162637155

## Any background context you want to add?
**Before**
<img width="1145" alt="screen shot 2018-12-13 at 12 43 15" src="https://user-images.githubusercontent.com/12892171/49939393-c922b780-feed-11e8-8e1c-d979bde8d387.png">

**After**
![image 2018-12-13 at 3 43 47 pm](https://user-images.githubusercontent.com/12892171/49939459-f7a09280-feed-11e8-91cb-ba10de2816ba.png)


## Important notes

## Packages installed

## Deployment note

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots