### PR TITLE
Ft Hide device spec step if has_spec is false

### DIFF
--- a/src/__test__/_components/AddAssetContainer.test.js
+++ b/src/__test__/_components/AddAssetContainer.test.js
@@ -189,4 +189,54 @@ describe('<AddAssetContainer /> test cases', () => {
     wrapper.instance().handleDropdownChanges(event, data);
     expect(wrapper.state().formState.selectedAssetMake).toEqual('MacBook Pro');
   });
+
+  it('shows device specs step if asset has specs', () => {
+    wrapper.setProps({ assetTypes: [{
+      asset_sub_category: 'Computers',
+      asset_type: 'MacBook',
+      has_specs: true,
+      id: 5,
+      last_modified: '2018-12-14T12:57:50.108712Z'
+    }] });
+
+    jest.spyOn(wrapper.instance(), 'handleDropdownChanges');
+
+    const event = {
+      stopPropagation: jest.fn(),
+      target: {}
+    };
+    const data = {
+      name: 'asset-types',
+      value: 'MacBook'
+    };
+
+    wrapper.instance().handleDropdownChanges(event, data);
+    wrapper.update();
+    expect(wrapper.find('StepDescription').length).toEqual(2);
+  });
+
+  it('hide device specs step if asset does not have specs', () => {
+    wrapper.setProps({ assetTypes: [{
+      asset_sub_category: 'Computers',
+      asset_type: 'MacBook',
+      has_specs: false,
+      id: 5,
+      last_modified: '2018-12-14T12:57:50.108712Z'
+    }] });
+
+    jest.spyOn(wrapper.instance(), 'handleDropdownChanges');
+
+    const event = {
+      stopPropagation: jest.fn(),
+      target: {}
+    };
+    const data = {
+      name: 'asset-types',
+      value: 'MacBook'
+    };
+
+    wrapper.instance().handleDropdownChanges(event, data);
+    wrapper.update();
+    expect(wrapper.find('StepDescription').length).toEqual(1);
+  });
 });

--- a/src/__test__/components/FilterAssetComponent.test.js
+++ b/src/__test__/components/FilterAssetComponent.test.js
@@ -36,6 +36,10 @@ describe('<FilterAssetComponent /> test cases', () => {
     wrapper.setProps(props);
   });
 
+  it('renders SaveButton component when asset specs are not available', () => {
+    expect(wrapper.find('SaveButton').dive().find('.save').props().buttonName).toBe('save');
+  });
+
   it('renders next button when asset specs are available', () => {
     wrapper.setProps({
       isAssetSpecsAvailable: true,

--- a/src/__test__/components/FilterAssetComponent.test.js
+++ b/src/__test__/components/FilterAssetComponent.test.js
@@ -44,14 +44,4 @@ describe('<FilterAssetComponent /> test cases', () => {
 
     expect(wrapper.find('ButtonComponent').props().buttonName).toBe('Next');
   });
-
-  it('displays a message when modelNumber, assetTag and serialNumber are not blank', () => {
-    wrapper.setProps({
-      modelNumber: 'yuhij',
-      assetTag: 'vgyuhijk',
-      serialNumber: 'vgyuhj'
-    });
-
-    expect(wrapper.find('SaveButton').dive().find('.optional-label-text').exists()).toBe(true);
-  });
 });

--- a/src/_components/Assets/AddAssetContainer.jsx
+++ b/src/_components/Assets/AddAssetContainer.jsx
@@ -16,7 +16,6 @@ import { loadAssetTypes } from '../../_actions/assetTypes.actions';
 import { loadAssetMakesDropdown } from '../../_actions/assetMakes.actions';
 import { loadModelNumbers } from '../../_actions/modelNumbers.actions';
 import { createAsset, resetMessage } from '../../_actions/asset.actions';
-// import { ACCEPTABLE_ASSET_TYPES } from '../../_enums';
 
 import {
   filterSubCategories,
@@ -199,7 +198,6 @@ class AddAssetContainer extends React.Component {
     const selectedAssetType = assetTypes.find(asset =>
       asset.asset_type === this.state.formState.selectedAssetType);
 
-    // null check if it is defined first
     const isAssetSpecsAvailable = selectedAssetType && selectedAssetType.has_specs;
 
     if (loading) {

--- a/src/_components/Assets/AddAssetContainer.jsx
+++ b/src/_components/Assets/AddAssetContainer.jsx
@@ -16,7 +16,7 @@ import { loadAssetTypes } from '../../_actions/assetTypes.actions';
 import { loadAssetMakesDropdown } from '../../_actions/assetMakes.actions';
 import { loadModelNumbers } from '../../_actions/modelNumbers.actions';
 import { createAsset, resetMessage } from '../../_actions/asset.actions';
-import { ACCEPTABLE_ASSET_TYPES } from '../../_enums';
+// import { ACCEPTABLE_ASSET_TYPES } from '../../_enums';
 
 import {
   filterSubCategories,
@@ -188,7 +188,7 @@ class AddAssetContainer extends React.Component {
 
   render() {
     const { step } = this.state;
-    const { loading, success, error } = this.props;
+    const { loading, success, error, assetTypes } = this.props;
     const isDisabled = this.stepValidator();
     let stepContent;
     let step1Active;
@@ -196,8 +196,11 @@ class AddAssetContainer extends React.Component {
 
     const showStatus = success || error;
 
-    const isAssetSpecsAvailable = ACCEPTABLE_ASSET_TYPES.indexOf(
-      this.state.formState.selectedAssetType) > -1;
+    const selectedAssetType = assetTypes.find(asset =>
+      asset.asset_type === this.state.formState.selectedAssetType);
+
+    // null check if it is defined first
+    const isAssetSpecsAvailable = selectedAssetType && selectedAssetType.has_specs;
 
     if (loading) {
       return (
@@ -286,13 +289,15 @@ class AddAssetContainer extends React.Component {
                   </Step.Content>
                 </Step>
 
-                <Step active={step2Active} disabled={step1Active}>
-                  <Icon name="list ul" />
-                  <Step.Content>
-                    <Step.Title>Device Specs</Step.Title>
-                    <Step.Description>Enter device specifications</Step.Description>
-                  </Step.Content>
-                </Step>
+                {isAssetSpecsAvailable &&
+                  <Step active={step2Active} disabled={step1Active}>
+                    <Icon name="list ul" />
+                    <Step.Content>
+                      <Step.Title>Device Specs</Step.Title>
+                      <Step.Description>Enter device specifications</Step.Description>
+                    </Step.Content>
+                  </Step>
+                }
               </Step.Group>
 
               {stepContent}

--- a/src/components/Assets/FilterAssetComponent.jsx
+++ b/src/components/Assets/FilterAssetComponent.jsx
@@ -177,16 +177,16 @@ FilterAssetComponent.propTypes = {
   selectedSubcategory: PropTypes.string,
   selectedAssetType: PropTypes.string,
   selectedAssetMake: PropTypes.string,
-  handleInputChange: PropTypes.func.isRequired,
+  handleInputChange: PropTypes.func,
   modelNumber: PropTypes.string,
   assetTag: PropTypes.string,
   serialNumber: PropTypes.string,
-  isAssetSpecsAvailable: PropTypes.bool.isRequired,
+  isAssetSpecsAvailable: PropTypes.bool,
   onCreateAsset: PropTypes.func.isRequired,
   reset: PropTypes.func
 };
 
-FilterAssetComponent.defaultTypes = {
+FilterAssetComponent.defaultProps = {
   filteredSubCategories: [],
   filteredAssetTypes: [],
   filteredAssetMakes: [],

--- a/src/components/Assets/FilterAssetComponent.jsx
+++ b/src/components/Assets/FilterAssetComponent.jsx
@@ -1,6 +1,5 @@
 import PropTypes from 'prop-types';
 import * as React from 'react';
-import _ from 'lodash';
 import { Form } from 'semantic-ui-react';
 import DropdownComponent from '../common/DropdownComponent';
 import ArtButton from '../common/ButtonComponent';
@@ -10,32 +9,18 @@ import generateDropdownOptions from '../../_utils/generateDropdownOptions';
 import '../../_css/AddAssetComponent.css';
 
 const SaveButton = props => (
-  <React.Fragment>
-    {
-        props.hasSpecs && (
-          <div className="optional-label-text">
-            <p>
-              The selected asset has no specifications, click the submit button to finish
-              creation
-            </p>
-          </div>
-        )
-      }
-
-    <ArtButton
-      className="save"
-      buttonName="save"
-      color="primary"
-      buttonState={props.buttonLoading}
-      disabledState={props.isDisabled || props.buttonLoading}
-      handleClick={props.handleClick}
-      fluidState
-    />
-  </React.Fragment>
+  <ArtButton
+    className="save"
+    buttonName="save"
+    color="primary"
+    buttonState={props.buttonLoading}
+    disabledState={props.isDisabled || props.buttonLoading}
+    handleClick={props.handleClick}
+    fluidState
+  />
 );
 
 SaveButton.propTypes = {
-  hasSpecs: PropTypes.bool.isRequired,
   buttonLoading: PropTypes.bool,
   isDisabled: PropTypes.bool.isRequired,
   handleClick: PropTypes.func
@@ -54,10 +39,6 @@ const FilterAssetComponent = (props) => {
 
     return categoryArray;
   };
-
-  const hasSpecs = !_.isEmpty(props.modelNumber) &&
-    !_.isEmpty(props.assetTag) &&
-    !_.isEmpty(props.serialNumber);
 
   return (
     <Form onSubmit={props.onCreateAsset} className="add-asset-form">
@@ -153,7 +134,6 @@ const FilterAssetComponent = (props) => {
             />
           :
             <SaveButton
-              hasSpecs={hasSpecs}
               buttonLoading={props.buttonLoading}
               isDisabled={props.isDisabled}
               handleClick={props.reset}


### PR DESCRIPTION
## What does this PR do?
Hides device specifications step (in the add assets page) if an asset does not have any specs

## Description of Task to be completed?
Same as ☝🏾

## How should this be manually tested?
On the `Add assets` page select an asset that has `has_specs = false`, the device specifications step should be hidden

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/n/projects/2146417/stories/161678740

## Any background context you want to add?
N/A

## Important notes

## Packages installed

## Deployment note

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
![screen shot 2018-12-17 at 16 19 53](https://user-images.githubusercontent.com/24937453/50096269-9f340280-0217-11e9-8ac2-aeacc30172ab.png)
