### PR TITLE
Bug fix

### DIFF
--- a/src/_reducers/officeLocations.reducer.js
+++ b/src/_reducers/officeLocations.reducer.js
@@ -27,7 +27,7 @@ export default (state = initialState.officeLocations, action) => {
     case LOAD_LOCATIONS_FAILURE:
       return {
         ...state,
-        error: action.payload,
+        error: action.payload.message || 'Oops, something went wrong',
         isLoading: false
       };
 

--- a/src/components/AndelaCentres/AndelaCentresComponent.jsx
+++ b/src/components/AndelaCentres/AndelaCentresComponent.jsx
@@ -38,6 +38,7 @@ class AndelaCentresComponent extends React.Component {
     const { isLoading, locationList, error, resetMessage } = this.props;
     const hasLocations = !isEmpty(locationList);
     const showStatus = error;
+    const showNotFound = !isLoading && !hasLocations && !showStatus;
 
     return (
       <NavBarComponent>
@@ -53,9 +54,9 @@ class AndelaCentresComponent extends React.Component {
           )}
         </div>
 
-        {isLoading && <LoaderComponent />}
+        {isLoading && !showStatus && <LoaderComponent />}
 
-        {(!isLoading && !hasLocations) && (
+        {showNotFound && (
           <ItemsNotFoundComponent
             header="No Andela Centres found!"
             message="Please try again later to see if there will be centres to show you"


### PR DESCRIPTION
## What does this PR do?
Fix a bug on staging on the Andela Centres page

## Description of Task to be completed?
The error status message and Not Found message should not appear a the same time

## How should this be manually tested?
Replicate an error message on the Andela Centres page. If there's an error message then only the status message will show and not the NotFound message nor the Loader.

## What are the relevant pivotal tracker stories?
[#162809998](https://www.pivotaltracker.com/n/projects/2146417/stories/162809998)

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
<img width="951" alt="screen shot 2018-12-21 at 15 38 52" src="https://user-images.githubusercontent.com/31322228/50343037-90f72680-0536-11e9-96c0-d73806d89f7c.png">
