### PR TITLE
Bg-Fetching assets

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,5 +94,11 @@
       "!src/registerServiceWorker.js",
       "!src/index.js"
     ]
-  }
+  },
+  "browserslist": [
+    ">0.2%",
+    "not dead",
+    "not ie <= 11",
+    "not op_mini all"
+  ]
 }

--- a/src/__test__/components/AssetsComponent.test.js
+++ b/src/__test__/components/AssetsComponent.test.js
@@ -89,4 +89,12 @@ describe('Renders <AssetsComponent /> correctly', () => {
     wrapper.instance().retrieveAssets(1, 10, '');
     expect(retrieveAssetsSpy.mock.calls.length).toEqual(1);
   });
+
+  it('shows filter button even when assets list is empty', () => {
+    wrapper.setProps({
+      assetsList: []
+    });
+
+    expect(wrapper.find('Filter').length).toBe(1);
+  });
 });

--- a/src/components/AssetsComponent.jsx
+++ b/src/components/AssetsComponent.jsx
@@ -96,11 +96,10 @@ export default class AssetsComponent extends Component {
     const { status } = this.props;
     const totalPages = this.handlePageTotal();
     const currentAssets = `page_${this.props.activePage}`;
-    const showFilter = !isEmpty(this.props.assetsList[currentAssets] || assets);
 
     return (
       <Fragment>
-        {showFilter && (
+        {
           <Filter
             activePage={this.props.activePage}
             limit={this.state.limit}
@@ -110,7 +109,7 @@ export default class AssetsComponent extends Component {
             filterAction={this.props.getAssetsAction}
             disabled={this.props.isLoading}
           />
-        )}
+        }
         <AssetsTableContent
           activePage={this.props.activePage}
           assets={this.props.assetsList[currentAssets] || assets}


### PR DESCRIPTION
## What does this PR do?
Shows `Filter` button even when there are no assets so user does not have to reload the page to re-apply filters

## Description of Task to be completed?
Same as ☝🏽

## How should this be manually tested?
Apply filters on the assets list page for `Magic Keyboard` even though it's an empty list the `Filter` button should still be visible so you can reapply another filter

## What are the relevant pivotal tracker stories?
https://www.pivotaltracker.com/story/show/162696252

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
