### PR TITLE
[162780351] Filter verified unverified assets

### DIFF
--- a/src/__test__/AllocationComponent.test.js
+++ b/src/__test__/AllocationComponent.test.js
@@ -13,9 +13,13 @@ describe('Renders <Allocations/> component', () => {
     loading: jest.fn(),
     resetAllocations: jest.fn(),
     setActivePage: jest.fn(),
-    activePage: 1
+    activePage: 1,
+    handleRowChange: jest.fn(),
+    retrieveAllocations: jest.fn(),
+    handlePaginationChange: jest.fn()
   };
 
+  const checkIfCutoffExceeded = () => {};
   let wrapper;
 
   beforeEach(() => {
@@ -28,6 +32,37 @@ describe('Renders <Allocations/> component', () => {
     });
 
     expect(wrapper.find('LoaderComponent').length).toBe(1);
+  });
+
+  it('calls handleRowChange when a  number of rows are selected', () => {
+    const handleRowChangeSpy = jest.spyOn(
+      wrapper.instance(), 'handleRowChange'
+    );
+    const event = {};
+    const data = {};
+    wrapper.instance().handleRowChange(event, data);
+    expect(handleRowChangeSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls the handlePaginationChange function when the next button is clicked', () => {
+    const handlePaginationChangeSpy = jest.spyOn(
+      wrapper.instance(), 'handlePaginationChange'
+    );
+    const event = {};
+    const data = {};
+    wrapper.instance().handlePaginationChange(event, data);
+    expect(handlePaginationChangeSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls retrieveAllocations ', () => {
+    const retrieveAllocationsSpy = jest.spyOn(
+      wrapper.instance(), 'retrieveAllocations'
+    );
+    const activePage = 1;
+    const limit = 10;
+    checkIfCutoffExceeded(activePage, limit);
+    wrapper.instance().retrieveAllocations(activePage, limit);
+    expect(retrieveAllocationsSpy.mock.calls.length).toEqual(1);
   });
 
   it('renders error if allocations fail to load', () => {

--- a/src/__test__/TableRowComponent.test.js
+++ b/src/__test__/TableRowComponent.test.js
@@ -46,8 +46,19 @@ describe('Renders <TableRowComponent /> correctly', () => {
     );
 
     const heading = '';
-
+    props.data[heading] = false;
     wrapper.instance().handleHeadings(heading);
     expect(handleHeadingsSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls handleHeadings for active user ', () => {
+    const handleHeadingsSpy = jest.spyOn(
+      wrapper.instance(), 'handleHeadings'
+    );
+
+    const heading = 'is_active';
+    props.data[heading] = true;
+    wrapper.instance().handleHeadings(heading);
+    expect(handleHeadingsSpy.mock.calls.length).toEqual(2);
   });
 });

--- a/src/__test__/TableRowComponent.test.js
+++ b/src/__test__/TableRowComponent.test.js
@@ -9,6 +9,8 @@ describe('Renders <TableRowComponent /> correctly', () => {
   const props = {
     viewDetailsRoute: '',
     data: assets[0],
+    handleClick: jest.fn(),
+    onClick: jest.fn(),
     headings: ['asset_type', 'asset_code', 'model_number']
   };
   const wrapper = shallow(<TableRowComponent {...props} />);
@@ -27,5 +29,25 @@ describe('Renders <TableRowComponent /> correctly', () => {
     );
     wrapper.instance().handleView();
     expect(handleViewSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls handleClick function when icon is clicked', () => {
+    const handleClickSpy = jest.spyOn(
+      wrapper.instance(), 'handleClick'
+    );
+
+    wrapper.instance().handleClick();
+    expect(handleClickSpy.mock.calls.length).toEqual(1);
+  });
+
+  it('calls handleHeadings', () => {
+    const handleHeadingsSpy = jest.spyOn(
+      wrapper.instance(), 'handleHeadings'
+    );
+
+    const heading = '';
+
+    wrapper.instance().handleHeadings(heading);
+    expect(handleHeadingsSpy.mock.calls.length).toEqual(1);
   });
 });

--- a/src/__test__/_components/AssetsContainer.test.js
+++ b/src/__test__/_components/AssetsContainer.test.js
@@ -65,6 +65,13 @@ describe('Renders <Assets />  tests', () => {
           { id: 2, option: 'Microsoft Lifechat LX-6000' },
           { id: 3, option: 'Spectre x360' }
         ]
+      },
+      {
+        title: 'Verification Status',
+        content: [
+          { id: 1, option: 'Verified' },
+          { id: 2, option: 'UnVerified' }
+        ]
       }
     ];
     expect(createFilterData(types, models)).toEqual(expected);

--- a/src/__test__/components/AssetModelsComponent.test.js
+++ b/src/__test__/components/AssetModelsComponent.test.js
@@ -12,7 +12,8 @@ describe('Renders <AssetModelsComponent /> correctly', () => {
     handlePaginationChange: jest.fn(),
     isLoading: false,
     assetModels,
-    assetModelsCount: 3
+    assetModelsCount: 3,
+    handleRowChange: jest.fn()
   };
 
   let wrapper = shallow(<AssetModelsComponent{...props} />);
@@ -56,5 +57,15 @@ describe('Renders <AssetModelsComponent /> correctly', () => {
 
     wrapper.instance().handleToggleModal();
     expect(wrapper.state().modalOpen).toEqual(true);
+  });
+
+  it('calls handleRowChange when a  number of rows are selected', () => {
+    const handleRowChangeSpy = jest.spyOn(
+      wrapper.instance(), 'handleRowChange'
+    );
+    const event = {};
+    const data = {};
+    wrapper.instance().handleRowChange(event, data);
+    expect(handleRowChangeSpy.mock.calls.length).toEqual(1);
   });
 });

--- a/src/__test__/components/AssetsSubCategoriesComponent.test.js
+++ b/src/__test__/components/AssetsSubCategoriesComponent.test.js
@@ -12,7 +12,8 @@ describe('Renders <AssetsSubCategoriesComponent /> correctly', () => {
     handlePaginationChange: jest.fn(),
     isLoading: false,
     assetSubCategories,
-    assetSubCategoriesCount: 10
+    assetSubCategoriesCount: 10,
+    handleRowChange: jest.fn()
   };
   let wrapper = shallow(<AssetSubCategoriesComponent
     {...props}
@@ -69,5 +70,15 @@ describe('Renders <AssetsSubCategoriesComponent /> correctly', () => {
 
     wrapper.instance().handleToggleModal();
     expect(wrapper.state().modalOpen).toEqual(true);
+  });
+
+  it('calls handleRowChange when a  number of rows are selected', () => {
+    const handleRowChangeSpy = jest.spyOn(
+      wrapper.instance(), 'handleRowChange'
+    );
+    const event = {};
+    const data = {};
+    wrapper.instance().handleRowChange(event, data);
+    expect(handleRowChangeSpy.mock.calls.length).toEqual(1);
   });
 });

--- a/src/_components/Assets/AssetsContainer.jsx
+++ b/src/_components/Assets/AssetsContainer.jsx
@@ -16,7 +16,6 @@ export const createFilterData = (assetTypes, assetModels) => {
 
   const formattedAssetTypes = assetTypes.map(assetType => formatOption(assetType, 'asset_type'));
   const formattedAssetModels = assetModels.map(assetModel => formatOption(assetModel, 'model_number'));
-
   return [
     {
       title: 'Asset Types',
@@ -25,6 +24,10 @@ export const createFilterData = (assetTypes, assetModels) => {
     {
       title: 'Model Numbers',
       content: formattedAssetModels
+    },
+    {
+      title: 'Verification Status',
+      content: [{ id: 1, option: 'verified' }, { id: 2, option: 'unverified' }]
     }
   ];
 };

--- a/src/_components/Assets/AssetsContainer.jsx
+++ b/src/_components/Assets/AssetsContainer.jsx
@@ -27,7 +27,7 @@ export const createFilterData = (assetTypes, assetModels) => {
     },
     {
       title: 'Verification Status',
-      content: [{ id: 1, option: 'verified' }, { id: 2, option: 'unverified' }]
+      content: [{ id: 1, option: 'Verified' }, { id: 2, option: 'UnVerified' }]
     }
   ];
 };

--- a/src/_mock/filters.js
+++ b/src/_mock/filters.js
@@ -5,7 +5,8 @@ const filters = [
 
 export const selectedFilters = {
   asset_types: ['Headsets'],
-  model_numbers: ['HP 27ES']
+  model_numbers: ['HP 27ES'],
+  'Verification Status': ['Verified', 'UnVerified']
 };
 
 export const userFilters = [

--- a/src/_reducers/checkedFilters.reducer.js
+++ b/src/_reducers/checkedFilters.reducer.js
@@ -7,7 +7,13 @@ const filtersReducer = (state = initialState.checkedFilters, action) => {
   switch (action.type) {
     case FILTER_SELECTED: {
       const { selection, filterType } = action;
-      const previousSelected = state[filterType] || [];
+      let previousSelected;
+
+      if (filterType === 'Verification Status') {
+        previousSelected = [];
+      } else {
+        previousSelected = state[filterType] || [];
+      }
 
       return {
         ...state,

--- a/src/_utils/assets.js
+++ b/src/_utils/assets.js
@@ -10,7 +10,8 @@ const constructUrl = (pageNumber, limit, filters = {}, status = '') => {
   if (!isEmpty(filters)) {
     url = `${url}&asset_type=${filters['Asset Types'] || ''}
     &model_number=${filters['Model Numbers'] || ''}
-    &serial_number=${filters['Serial Number'] || ''}`;
+    &serial_number=${filters['Serial Number'] || ''}
+    &verified=${filters['Verification Status'] || ''}`;
   }
   return url;
 };

--- a/src/components/AssetsComponent.jsx
+++ b/src/components/AssetsComponent.jsx
@@ -133,7 +133,7 @@ export default class AssetsComponent extends Component {
 
 AssetsComponent.propTypes = {
   assetsCount: PropTypes.number.isRequired,
-  assetsList: PropTypes.array,
+  assetsList: PropTypes.object,
   errorMessage: PropTypes.string,
   getAssetsAction: PropTypes.func.isRequired,
   setActivePage: PropTypes.func.isRequired,

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -54,6 +54,7 @@ const AssetsTableContent = (props) => {
             <Table.HeaderCell>Asset Make</Table.HeaderCell>
             <Table.HeaderCell>Asset Type</Table.HeaderCell>
             <Table.HeaderCell>Assigned To</Table.HeaderCell>
+            <Table.HeaderCell>Verification Status</Table.HeaderCell>
           </Table.Row>
         </Table.Header>
 
@@ -66,7 +67,8 @@ const AssetsTableContent = (props) => {
               asset_code: asset.asset_code || '-',
               serial_number: asset.serial_number || '-',
               model_number: asset.model_number || '-',
-              assignee: getAssignee(asset.assigned_to)
+              assignee: getAssignee(asset.assigned_to),
+              verified: asset.verified
             };
 
             return (
@@ -80,7 +82,8 @@ const AssetsTableContent = (props) => {
                   'model_number',
                   'make_label',
                   'asset_type',
-                  'assignee'
+                  'assignee',
+                  'verified'
                 ]}
               />
             );

--- a/src/components/AssetsTableContent.jsx
+++ b/src/components/AssetsTableContent.jsx
@@ -67,8 +67,7 @@ const AssetsTableContent = (props) => {
               asset_code: asset.asset_code || '-',
               serial_number: asset.serial_number || '-',
               model_number: asset.model_number || '-',
-              assignee: getAssignee(asset.assigned_to),
-              verified: asset.verified
+              assignee: getAssignee(asset.assigned_to)
             };
 
             return (

--- a/src/components/TableRowComponent.jsx
+++ b/src/components/TableRowComponent.jsx
@@ -24,6 +24,14 @@ export class TableRowComponent extends React.Component {
       }
     }
 
+    if (this.props.data[heading] === true) {
+      return 'Yes';
+    }
+
+    if (this.props.data[heading] === false) {
+      return 'No';
+    }
+
     return this.props.data[heading];
   }
 

--- a/src/components/TableRowComponent.jsx
+++ b/src/components/TableRowComponent.jsx
@@ -18,8 +18,10 @@ export class TableRowComponent extends React.Component {
   }
 
   handleHeadings = (heading) => {
-    if (this.props.data[heading] === true || this.props.data[heading] === false) {
-      return (<IsActiveContainer securityUser={this.props.data} />);
+    if (heading === 'is_active') {
+      if (this.props.data[heading] === true || this.props.data[heading] === false) {
+        return (<IsActiveContainer securityUser={this.props.data} />);
+      }
     }
 
     return this.props.data[heading];

--- a/src/components/common/Filter/FilterButton.jsx
+++ b/src/components/common/Filter/FilterButton.jsx
@@ -41,7 +41,6 @@ class FilterButton extends React.Component {
       }
     }
 
-
     this.props.filterAction(
       this.props.activePage,
       this.props.limit,

--- a/src/components/common/Filter/FilterButton.jsx
+++ b/src/components/common/Filter/FilterButton.jsx
@@ -21,6 +21,27 @@ class FilterButton extends React.Component {
     this.handleClose();
     const { selected } = this.props;
 
+    if (this.props.selected['Verification Status']) {
+      if (this.props.selected['Verification Status'][0] === 'verified') {
+        this.props.selected['Verification Status'][0] = true;
+      }
+      if (this.props.selected['Verification Status'][1] === 'verified') {
+        this.props.selected['Verification Status'][0] = true;
+      }
+      if (this.props.selected['Verification Status'][0] === 'unverified') {
+        this.props.selected['Verification Status'][0] = false;
+      }
+      if (this.props.selected['Verification Status'][1] === 'unverified') {
+        this.props.selected['Verification Status'][1] = false;
+      }
+      if (this.props.selected['Verification Status'][0] === 'verified' || this.props.selected['Verification Status'][1] === 'verified') {
+        if (this.props.selected['Verification Status'][0] === 'unverified' || this.props.selected['Verification Status'][1] === 'unverified') {
+          this.props.selected['Verification Status'] = null;
+        }
+      }
+    }
+
+
     this.props.filterAction(
       this.props.activePage,
       this.props.limit,

--- a/src/components/common/Filter/FilterButton.jsx
+++ b/src/components/common/Filter/FilterButton.jsx
@@ -22,20 +22,20 @@ class FilterButton extends React.Component {
     const { selected } = this.props;
 
     if (this.props.selected['Verification Status']) {
-      if (this.props.selected['Verification Status'][0] === 'verified') {
+      if (this.props.selected['Verification Status'][0] === 'Verified') {
         this.props.selected['Verification Status'][0] = true;
       }
-      if (this.props.selected['Verification Status'][1] === 'verified') {
+      if (this.props.selected['Verification Status'][1] === 'Verified') {
         this.props.selected['Verification Status'][0] = true;
       }
-      if (this.props.selected['Verification Status'][0] === 'unverified') {
+      if (this.props.selected['Verification Status'][0] === 'UnVerified') {
         this.props.selected['Verification Status'][0] = false;
       }
-      if (this.props.selected['Verification Status'][1] === 'unverified') {
+      if (this.props.selected['Verification Status'][1] === 'UnVerified') {
         this.props.selected['Verification Status'][1] = false;
       }
-      if (this.props.selected['Verification Status'][0] === 'verified' || this.props.selected['Verification Status'][1] === 'verified') {
-        if (this.props.selected['Verification Status'][0] === 'unverified' || this.props.selected['Verification Status'][1] === 'unverified') {
+      if (this.props.selected['Verification Status'][0] === 'Verified' || this.props.selected['Verification Status'][1] === 'Verified') {
+        if (this.props.selected['Verification Status'][0] === 'UnVerified' || this.props.selected['Verification Status'][1] === 'UnVerified') {
           this.props.selected['Verification Status'] = null;
         }
       }

--- a/src/components/common/Filter/FilterComponent.jsx
+++ b/src/components/common/Filter/FilterComponent.jsx
@@ -55,12 +55,22 @@ class FilterComponent extends React.Component {
                   const label = isNull(opt.option) ? 'unspecified' : opt.option;
                   const selectedOptions = this.props.selected[option.title] || [];
 
+                  const check = () => {
+                    if (selectedOptions[0] === true) {
+                      selectedOptions[0] = 'verified';
+                    }
+                    if (selectedOptions[0] === false) {
+                      selectedOptions[0] = 'unverified';
+                    }
+                    return selectedOptions.includes((label).toString());
+                  };
+
                   return (
                     <CheckboxComponent
                       key={uuidv4()}
                       label={label}
                       name={option.title}
-                      isChecked={selectedOptions.includes((label).toString())}
+                      isChecked={check()}
                       handleCheckboxChange={this.handleCheckboxChange}
                     />
                   );

--- a/src/components/common/Filter/FilterComponent.jsx
+++ b/src/components/common/Filter/FilterComponent.jsx
@@ -57,10 +57,10 @@ class FilterComponent extends React.Component {
 
                   const check = () => {
                     if (selectedOptions[0] === true) {
-                      selectedOptions[0] = 'verified';
+                      selectedOptions[0] = 'Verified';
                     }
                     if (selectedOptions[0] === false) {
-                      selectedOptions[0] = 'unverified';
+                      selectedOptions[0] = 'UnVerified';
                     }
                     return selectedOptions.includes((label).toString());
                   };

--- a/src/components/common/Filter/FilterComponent.jsx
+++ b/src/components/common/Filter/FilterComponent.jsx
@@ -28,9 +28,6 @@ class FilterComponent extends React.Component {
       isChecked: checked
     };
 
-    console.log('option>>>>>>>>>>>>', this.props.option);
-    console.log('ischecked>>>>>>>>>>>', checked);
-
     this.props.filterSelection(selection, option.title);
   };
 

--- a/src/components/common/Filter/FilterComponent.jsx
+++ b/src/components/common/Filter/FilterComponent.jsx
@@ -28,6 +28,9 @@ class FilterComponent extends React.Component {
       isChecked: checked
     };
 
+    console.log('option>>>>>>>>>>>>', this.props.option);
+    console.log('ischecked>>>>>>>>>>>', checked);
+
     this.props.filterSelection(selection, option.title);
   };
 


### PR DESCRIPTION
## What does this PR do?
Enables a user to filter assets by either verified or unverified.

## Description of Task to be completed?
Add verified/unverified as filter options.
Add functionality to enable filters to be applied

## How should this be manually tested?
Head on to the Assets list page, click on the filter button to view all options. Filter by either verified or unverified.

## What are the relevant pivotal tracker stories?
[#162780351](https://www.pivotaltracker.com/n/projects/2146417/stories/162780351)

## Any background context you want to add?
N/A

## Important notes
The task is not complete. One can only filter by either verified and unverified but not both.

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots
![screen recording 2019-02-06 at 06 57 pm](https://user-images.githubusercontent.com/31322228/52358759-43307200-2a41-11e9-8fe8-43cd7482b138.gif)


![screen recording 2019-02-06 at 07 00 pm](https://user-images.githubusercontent.com/31322228/52358945-9276a280-2a41-11e9-998b-d2145398d06a.gif)
