### PR TITLE
#163756068 Fix add security user form submission

### DIFF
--- a/src/components/SecurityUser/AddSecurityUserComponent.jsx
+++ b/src/components/SecurityUser/AddSecurityUserComponent.jsx
@@ -35,7 +35,7 @@ class AddSecurityUserComponent extends Component {
   handleSubmit = (event) => {
     event.preventDefault();
 
-    if (this.state.emailValid) {
+    if (!this.state.emailValid) {
       return null;
     }
 


### PR DESCRIPTION
## What does this PR do?
Fixes a bug in the security user creation form

## Description of Task to be completed?
```
The add security user form does not submit even when the details entered are correct.
```

## How should this be manually tested?
* Log in
* Click on the `Users` link on the navigation bar
* Click on the `Security Users` tab
* Click on the `ADD SECURITY USER` button to open the modal
* Fill in security user details and submit the form

## What are the relevant pivotal tracker stories?
[163756068](https://www.pivotaltracker.com/story/show/163756068)

## Any background context you want to add?
N/A

## Important notes
N/A

## Packages installed
N/A

## Deployment note
N/A

## Related PRs branch | PR (branch_name) | (pr_link)
N/A

## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation

## Screenshots
N/A