### PR TITLE
bug: fetch assets after search

### DIFF
--- a/src/__test__/_components/AssetsContainer.test.js
+++ b/src/__test__/_components/AssetsContainer.test.js
@@ -13,7 +13,8 @@ describe('Renders <Assets />  tests', () => {
         errorMessage: '',
         hasError: false,
         activePage: 1,
-        status: ''
+        status: '',
+        filters: ''
       },
       assetModelsList: {
         assetModel: []
@@ -27,7 +28,8 @@ describe('Renders <Assets />  tests', () => {
     const ownProps = {
       match: {
         params: {
-          status: ''
+          status: '',
+          filters: ''
         }
       }
     };
@@ -42,7 +44,9 @@ describe('Renders <Assets />  tests', () => {
       activePage: 1,
       selected: [],
       status: '',
-      shouldReload: false
+      filters: '',
+      shouldReload: false,
+      reloadAfterSearch: false
     };
 
     expect(mapStateToProps(state, ownProps)).toEqual(expected);

--- a/src/__test__/actions/assets.action.test.js
+++ b/src/__test__/actions/assets.action.test.js
@@ -43,7 +43,8 @@ describe('Asset Types action tests', () => {
       expect(store.getActions()).toContainEqual({
         payload: assets,
         type: 'LOAD_ASSETS_SUCCESS',
-        status: ''
+        status: '',
+        filters: {}
       });
     });
   });

--- a/src/__test__/components/AssetsComponent.test.js
+++ b/src/__test__/components/AssetsComponent.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { shallow } from 'enzyme';
+import { shallow, mount } from 'enzyme';
 import expect from 'expect';
 
 import AssetsComponent from '../../components/AssetsComponent';
@@ -30,13 +30,16 @@ describe('Renders <AssetsComponent /> correctly', () => {
     assetsList: [],
     loading: jest.fn(),
     match: {
-      params: { status: '' }
+      params: { status: '', filters: '' }
     },
     handlePageTotal: jest.fn(),
     location: {
       pathname: '/assets/allocated'
-    }
+    },
+    shouldReload: false,
+    reloadAfterSearch: false
   };
+
   const wrapper = shallow(<AssetsComponent
     {...props}
   />);
@@ -103,5 +106,27 @@ describe('Renders <AssetsComponent /> correctly', () => {
     });
 
     expect(wrapper.find('Filter').length).toBe(1);
+  });
+
+  it('renders the AssetsTableContent component when loading only allocated asets', () => {
+    wrapper.setProps({
+      match: { params: { status: 'allocated' } },
+      shouldReload: true });
+    expect(wrapper.find('AssetsTableContent').length).toBe(1);
+  });
+
+  it('renders the AssetsTableContent component when searching for an asset', () => {
+    wrapper.setProps({
+      match: { params: { filters: '87878' } },
+      reloadAfterSearch: true });
+    expect(wrapper.find('AssetsTableContent').length).toBe(1);
+  });
+
+  it('loads AssetsComponent with filtered assets', () => {
+    props.match.params.filters = '87878';
+    const wrapper2 = mount(<AssetsComponent
+      {...props}
+    />);
+    expect(wrapper2.props().match).toEqual({ params: { filters: '87878', status: '' } });
   });
 });

--- a/src/__test__/reducers/assets.reducer.test.js
+++ b/src/__test__/reducers/assets.reducer.test.js
@@ -48,7 +48,8 @@ const state = {
 let action = {
   payload: {
     results: assets
-  }
+  },
+  filters: {}
 };
 
 const error = {

--- a/src/_actions/assets.action.js
+++ b/src/_actions/assets.action.js
@@ -19,7 +19,7 @@ const {
   EXPORT_ASSETS_FAILURE
 } = constants;
 
-export const getAssetsAction = (pageNumber, limit, filters, status = '') => {
+export const getAssetsAction = (pageNumber, limit, filters = {}, status = '') => {
   const url = constructUrl(pageNumber, limit, filters, status);
 
   return (dispatch) => {
@@ -28,11 +28,11 @@ export const getAssetsAction = (pageNumber, limit, filters, status = '') => {
     return fetchData(url)
       .then((response) => {
         dispatch(loading(false));
-        dispatch(getAssetsSuccess(response.data, status));
+        dispatch(getAssetsSuccess(response.data, status, filters));
       })
       .catch((error) => {
         dispatch(loading(false));
-        dispatch(getAssetsFailure(error.message, status));
+        dispatch(getAssetsFailure(error.message, status), filters);
       });
   };
 };
@@ -87,10 +87,11 @@ export const uploading = isUpLoading => ({
   isUpLoading
 });
 
-const getAssetsSuccess = (data, status = 'all') => ({
+const getAssetsSuccess = (data, status = 'all', filters = {}) => ({
   type: LOAD_ASSETS_SUCCESS,
   payload: data,
-  status
+  status,
+  filters
 });
 
 const getAssetsFailure = (message, status = 'all') => ({

--- a/src/_components/Assets/AssetsContainer.jsx
+++ b/src/_components/Assets/AssetsContainer.jsx
@@ -41,7 +41,6 @@ export const createFilterData = (assetTypes, assetModels) => {
 export const mapStateToProps = (state, ownProps) => {
   const { assets, assetTypesList, assetModelsList, selected } = state;
   const { params } = ownProps.match;
-
   const {
     assetsList,
     assetsCount,
@@ -50,13 +49,16 @@ export const mapStateToProps = (state, ownProps) => {
     hasError,
     isLoading,
     activePage,
-    status
+    status,
+    filters
   } = assets;
   const { assetModels } = assetModelsList;
   const { assetTypes } = assetTypesList;
 
   const assetAdjective = params.status || '';
-  const shouldReload = assetAdjective !== assets.status;
+  const assetAdjectiveAfterSearh = params.filters || '';
+  const reloadAfterSearch = assetAdjectiveAfterSearh !== filters;
+  const shouldReload = assetAdjective !== status;
 
   return {
     assetsList,
@@ -69,7 +71,9 @@ export const mapStateToProps = (state, ownProps) => {
     activePage,
     selected,
     status,
-    shouldReload
+    shouldReload,
+    filters,
+    reloadAfterSearch
   };
 };
 

--- a/src/_components/Assets/AssetsContainer.jsx
+++ b/src/_components/Assets/AssetsContainer.jsx
@@ -56,8 +56,8 @@ export const mapStateToProps = (state, ownProps) => {
   const { assetTypes } = assetTypesList;
 
   const assetAdjective = params.status || '';
-  const assetAdjectiveAfterSearh = params.filters || '';
-  const reloadAfterSearch = assetAdjectiveAfterSearh !== filters;
+  const assetAdjectiveAfterSearch = params.filters || '';
+  const reloadAfterSearch = assetAdjectiveAfterSearch !== filters;
   const shouldReload = assetAdjective !== status;
 
   return {

--- a/src/_components/RoutesComponent.jsx
+++ b/src/_components/RoutesComponent.jsx
@@ -76,6 +76,12 @@ class RoutesComponent extends Component {
           <Authenticate
             exact
             isAuthenticated={this.checkAuthentication()}
+            path="/assets/:filters/search"
+            component={Assets}
+          />
+          <Authenticate
+            exact
+            isAuthenticated={this.checkAuthentication()}
             path="/asset-models"
             component={AssetModels}
           />

--- a/src/_reducers/assets.reducer.js
+++ b/src/_reducers/assets.reducer.js
@@ -120,7 +120,8 @@ export default (state = initialState.assets, action) => {
         assetsCount: action.payload.count,
         hasError: false,
         isLoading: action.isLoading,
-        status: action.status
+        status: action.status,
+        filters: action.filters['Serial Number']
       };
 
     case SET_ACTIVE_PAGE:

--- a/src/_utils/assets.js
+++ b/src/_utils/assets.js
@@ -3,7 +3,7 @@ import { isEmpty } from 'lodash';
 const constructUrl = (pageNumber, limit, filters = {}, status = '') => {
   let url = `manage-assets?page=${pageNumber}&page_size=${limit}`;
 
-  if (status) {
+  if (!isEmpty(status)) {
     url = `${url}&current_status=${status}`;
   }
 

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -76,11 +76,12 @@ export class NavBarComponent extends Component {
 
   handleSearch = (event) => {
     event.stopPropagation();
-    const { location } = this.props;
-    if (location.pathname === '/assets' && event.key === 'Enter') {
+    const { location, history } = this.props;
+    if (location.pathname.includes('/assets') && event.key === 'Enter') {
       const { pageNumber, limit, value } = this.state;
       this.props.getAssetsAction(pageNumber, limit, value);
       this.setState({ value: { 'Serial Number': '' } });
+      history.push(`/assets/${value['Serial Number']}/search`);
     }
   }
 
@@ -177,7 +178,7 @@ export class NavBarComponent extends Component {
                         {nav.title}
                       </span>
                     </NavLink>
-                  ))
+                      ))
                 }
               </div>
             }

--- a/src/components/NavBarComponent.jsx
+++ b/src/components/NavBarComponent.jsx
@@ -178,7 +178,7 @@ export class NavBarComponent extends Component {
                         {nav.title}
                       </span>
                     </NavLink>
-                      ))
+                  ))
                 }
               </div>
             }


### PR DESCRIPTION
## What does this PR do?
- Fix the bug to reload asset after searching

## Description of Task to be completed?
After searching an asset, 
- back buttons should go to the previous list of assets.
- Assets tab should fetch the list of assets.

## How should this be manually tested?

## What are the relevant pivotal tracker stories?

## Any background context you want to add?

## Important notes

## Packages installed

## Deployment note

## Related PRs branch | PR (branch_name) | (pr_link)
Branch | PR
------ | ------
other_pr_production | [link]()
other_pr_master | [link]()
## Todos
- [x] Raise PR
- [ ] Test
- [ ] Documentation
## Screenshots